### PR TITLE
Changing required number of signatures to 3 for stable and exp

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -146,7 +146,7 @@
           'http://[fdef:ffc0:4fff::130]/experimental/sysupgrade/',
         },
         probability = 0.5,
-        good_signatures = 3,
+        good_signatures = 2,
         pubkeys = {
           '2a74ed02120a7d48bb2dc9be988b3480ed99844054b3d7f3e5d3df27d19d814b', -- ole
           '7e3bd782e40189b903b3fb1e488d64b23aa04bc353b1a521b4cd50e70b299113', -- fpletz

--- a/site.conf
+++ b/site.conf
@@ -131,7 +131,7 @@
           'http://[fdef:ffc0:4fff::130]/stable/sysupgrade/',
         },
         probability = 0.1,
-        good_signatures = 2,
+        good_signatures = 3,
         pubkeys = {
           '2a74ed02120a7d48bb2dc9be988b3480ed99844054b3d7f3e5d3df27d19d814b', -- ole
           '7e3bd782e40189b903b3fb1e488d64b23aa04bc353b1a521b4cd50e70b299113', -- fpletz
@@ -146,8 +146,11 @@
           'http://[fdef:ffc0:4fff::130]/experimental/sysupgrade/',
         },
         probability = 0.5,
-        good_signatures = 1,
+        good_signatures = 3,
         pubkeys = {
+          '2a74ed02120a7d48bb2dc9be988b3480ed99844054b3d7f3e5d3df27d19d814b', -- ole
+          '7e3bd782e40189b903b3fb1e488d64b23aa04bc353b1a521b4cd50e70b299113', -- fpletz
+          '56c4201f6ce2994678b0142e19099dd28d6ed17775d35ca9a7f12d9235890ffc', -- chris
           '2f92051ac4452d6026061e6c3719ffbd4f34ba7fbc474439fc6f857b76159bae', -- build.freifunk-muenchen.de (fpletz)
         },
       },


### PR DESCRIPTION
Um das bereits lang angedachte (und schon ewig kommunizierte) >4 Augen Prinzip bei FW Releases einzufuehren, wird die Anzahl der benoetigten Signaturen hochgesetzt.

Dies ist auch bei Experimental Images der Fall, da Images die ueber Experimental Autoupdater ins Produktivnetz ausgerollt werden, bereits vorher in einem autarken Testbed getestet worden sein sollen.