### PR TITLE
Updated to Gluon v2016.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 UNRELEASED
 
-- Updated to Gluon v2016.2 (upstream)
+- Updated to Gluon v2016.2.3 (upstream)
   - Changes:
-    https://gluon.readthedocs.org/en/v2016.2/releases/v2016.2.html
+    - https://gluon.readthedocs.io/en/v2016.2.3/releases/v2016.1.6.html
+    - https://gluon.readthedocs.io/en/v2016.2.3/releases/v2016.2.html
+    - https://gluon.readthedocs.io/en/v2016.2.3/releases/v2016.2.1.html
+    - https://gluon.readthedocs.io/en/v2016.2.3/releases/v2016.2.2.html
+    - https://gluon.readthedocs.io/en/v2016.2.3/releases/v2016.2.3.html
 - site.mk
   - added GLUON_REGION = eu setting
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := a54e7654cda80c8b9ea3fc991719c1e254c4f995
+GLUON_GIT_REF := b0c647151c6b4889bca8f9226c1456179e86b25b
 
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Check out this repository and execute `make`, i.e. like this:
 
 ## Further Resources
 
-Look at the [site configuration related Gluon documentation](http://gluon.readthedocs.org/en/v2016.1/user/site.html)
+Look at the [site configuration related Gluon documentation](https://gluon.readthedocs.io/en/v2016.2.3/user/site.html)
 for information on site configuration options and examples from other communities.


### PR DESCRIPTION
This adds support for current TP-Link devices, in particular:
- TL-WR841ND v11 EU
- CPE210/510 EU
- TP-Link TL-WR1043ND v4
- TP-Link TL-WR940N v4