### PR TITLE
Makefile: Introduce GLUON_ATH10K_MESH variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Freifunk München Firmware Changelog
 
+## v2017.2
+
+UNRELEASED
+
+ - Makefile
+   - Enabled firmware with ath10k WLAN driver
+
 ## v2017.1
 
  - Updated to Gluon v2017.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@
 
 UNRELEASED
 
+ - Updated to Gluon v2016.2.7-2-g3d824bd2
+   - ar71xx: fix MAC addresses on TP-Link TL-WR1043ND v4
+   - modules: update url to chaos calmer git repository after upstream move
+
  - Makefile
    - Enabled firmware with ath10k WLAN driver
 
 ## v2017.1
 
- - Updated to Gluon v2017.7
+ - Updated to Gluon v2016.2.7
    - Changes:
-     - https://gluon.readthedocs.io/en/v2016.2.7/releases/v2016.1.7.html
+     - https://gluon.readthedocs.io/en/v2016.2.7/releases/v2016.2.7.html
 
 ## v2017.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Freifunk München Firmware Changelog
 
-## v2017.2
+## v2018.0
 
 UNRELEASED
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ JOBS ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)
 
 GLUON_MAKE := ${MAKE} -j ${JOBS} -C ${GLUON_BUILD_DIR} \
 			GLUON_RELEASE=${GLUON_RELEASE} \
-			GLUON_BRANCH=${GLUON_BRANCH}
+			GLUON_BRANCH=${GLUON_BRANCH} \
+			GLUON_ATH10K_MESH=ibss
 
 all: info
 	${MAKE} manifest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2016.2.7
+GLUON_GIT_REF := 3d824bd21d7f6d5db6dc238d2a68b62de471aa2a
 
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 


### PR DESCRIPTION
The new Make variable has been introduced in Gluon v2016.2. If set, it enables additional firmware images for new devices.

Has been successfully tested on [TP-Link Archer C5 v1](http://lists.freifunk.net/mailman/private/muenchen-freifunk.net/2018-February/003028.html) and [TP-Link Archer C7 v2](http://lists.freifunk.net/mailman/private/muenchen-freifunk.net/2018-February/003030.html).