### PR TITLE
CHANGELOG - ffmuc_wiki to ffmuc_welt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## v2019.0.5
   - Domains:
     - add gw07 for new segments
-    - remove legacy domains (will fallback to ffmuc_wiki)
+    - remove legacy domains (will fallback to ffmuc_world)
   - Docs:
     - remove hint to lqfb.freifunk-muenchen.de as it is offline
       (thanks to @T0biii in #59)


### PR DESCRIPTION
Fallback Domain is ffmuc_welt or not?
Merge in experimental this time :)