### PR TITLE
Use "make download all" for gluon build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ info:
 build: gluon-prepare
 	for target in ${GLUON_TARGETS}; do \
 		echo ""Building target $$target""; \
-		${GLUON_MAKE} GLUON_TARGET="$$target"; \
+		${GLUON_MAKE} download all GLUON_TARGET="$$target"; \
 	done
 
 manifest: build


### PR DESCRIPTION
OpenWRT does have issues with multi-threaded builds, caused by the source downloads triggered while building. This can be mitigated by doing the download explicitly in advance.