### PR TITLE
site.conf: remove last slash from autoupdater mirror url

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -52,8 +52,8 @@
       wireguard = {
         name = 'wireguard',
         mirrors = {
-          'http://firmware.ffmuc.net/wireguard/sysupgrade/',
-          'http://[2001:608:a01::27]/wireguard/sysupgrade/',
+          'http://firmware.ffmuc.net/wireguard/sysupgrade',
+          'http://[2001:608:a01::27]/wireguard/sysupgrade',
         },
         good_signatures = 1,
         pubkeys = {
@@ -68,8 +68,8 @@
       stable = {
         name = 'stable',
         mirrors = {
-          'http://firmware.ffmuc.net/stable/sysupgrade/',
-          'http://[2001:608:a01::27]/stable/sysupgrade/',
+          'http://firmware.ffmuc.net/stable/sysupgrade',
+          'http://[2001:608:a01::27]/stable/sysupgrade',
         },
         good_signatures = 3,
         pubkeys = {
@@ -84,8 +84,8 @@
       testing = {
         name = 'testing',
         mirrors = {
-          'http://firmware.ffmuc.net/testing/sysupgrade/',
-          'http://[2001:608:a01::27]/testing/sysupgrade/',
+          'http://firmware.ffmuc.net/testing/sysupgrade',
+          'http://[2001:608:a01::27]/testing/sysupgrade',
         },
         good_signatures = 2,
         pubkeys = {
@@ -100,8 +100,8 @@
       experimental = {
         name = 'experimental',
         mirrors = {
-          'http://firmware.ffmuc.net/experimental/sysupgrade/',
-          'http://[2001:608:a01::27]/experimental/sysupgrade/',
+          'http://firmware.ffmuc.net/experimental/sysupgrade',
+          'http://[2001:608:a01::27]/experimental/sysupgrade',
         },
         good_signatures = 1,
         pubkeys = {


### PR DESCRIPTION
It doesn't look nice with the double slash:

```
root@tomh-virtual-test1:~# gluon-wan autoupdater -b stable --force-version
Retrieving manifest from http://[2001:608:a01::27]/stable/sysupgrade//stable.manifest ...

autoupdater: warning: error downloading manifest: Connection failed
Retrieving manifest from http://firmware.ffmuc.net/stable/sysupgrade//stable.manifest ...
```