### PR TITLE
Update firmware server IP address for all branches

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -70,7 +70,8 @@
         name = 'stable',
         mirrors = {
           'http://firmware.ffmuc.net/stable/sysupgrade',
-          'http://[2001:608:a01::27]/stable/sysupgrade',
+          'http://5.1.66.255/stable/sysupgrade',
+          'http://[2001:678:e68:f000::]/stable/sysupgrade',
         },
         good_signatures = 3,
         pubkeys = {
@@ -86,7 +87,8 @@
         name = 'testing',
         mirrors = {
           'http://firmware.ffmuc.net/testing/sysupgrade',
-          'http://[2001:608:a01::27]/testing/sysupgrade',
+          'http://5.1.66.255/testing/sysupgrade',
+          'http://[2001:678:e68:f000::]/testing/sysupgrade',
         },
         good_signatures = 2,
         pubkeys = {
@@ -102,7 +104,8 @@
         name = 'experimental',
         mirrors = {
           'http://firmware.ffmuc.net/experimental/sysupgrade',
-          'http://[2001:608:a01::27]/experimental/sysupgrade',
+          'http://5.1.66.255/experimental/sysupgrade',
+          'http://[2001:678:e68:f000::]/experimental/sysupgrade',
         },
         good_signatures = 1,
         pubkeys = {


### PR DESCRIPTION
Changed IP-address for firmware update to new AS212567 addresses. Include a IPv4 address in addition to the IPv6 address, in case one of the networks is not working as expected (as it happened in the last migration).