### PR TITLE
Break the build in case patches cannot be applied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,15 +71,16 @@ ${GLUON_BUILD_DIR}:
 	git clone ${GLUON_GIT_URL} ${GLUON_BUILD_DIR}
 
 gluon-prepare: output-clean ${GLUON_BUILD_DIR}
-	(cd ${GLUON_BUILD_DIR} \
+	cd ${GLUON_BUILD_DIR} \
 		&& git remote set-url origin ${GLUON_GIT_URL} \
 		&& git fetch origin \
-		&& rm -rf package packages \
-		&& git checkout -q --force ${GLUON_GIT_REF}) \
-		&& git clean -fd
+		&& rm -rf packages \
+		&& git checkout -q --force ${GLUON_GIT_REF} \
+		&& git clean -fd;
 	ln -sfT .. ${GLUON_BUILD_DIR}/site
 	make gluon-patch
 	${GLUON_MAKE} update
+
 gluon-patch:
 	echo "Applying Patches ..."
 	(cd ${GLUON_BUILD_DIR})
@@ -89,12 +90,11 @@ gluon-patch:
 	(cd ${GLUON_BUILD_DIR}; git checkout -B patching)
 	if [ -d "gluon-build/site/patches" -a "gluon-build/site/patches/*.patch" ]; then \
 		(cd ${GLUON_BUILD_DIR}; git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn site/patches/*.patch) || ( \
-			cd ${GLUON_BUILD_DIR} \
-			git clean -fd \
-			git am --abort \
-			git checkout -B patched \
-			git branch -D patching \
-			false \
+			cd ${GLUON_BUILD_DIR}; \
+			git clean -fd; \
+			git checkout -B patched; \
+			git branch -D patching; \
+			exit 1 \
 		) \
 	fi
 	(cd ${GLUON_BUILD_DIR}; git branch -M patched)


### PR DESCRIPTION
Currently the build doesn't fail in case patches are broken or no longer
valid. This change tries to mitigate this issue. However the way patches
are currently handled and applied is error prone and needs more rework,
e.g. deleting packages before every build is just a workaround because
there is no proper way to clean them up. There must be a better way to
deal with patches, which do not change gluon code directly, but OpenWRT or
package code.