### PR TITLE
Don't trigger build workflow for every new branch

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -2,7 +2,7 @@ name: Build ffmuc firmware
 
 on:
   workflow_dispatch:
-  create:
+  push:
     tags:
       - v*
 


### PR DESCRIPTION
The "create" event does not support branch/tag filter, so it will
trigger for every branch created, use the branch name as tag and create
a release called "refs/head/branchname". Use "push" instead to avoid
this.