### PR TITLE
Increase delay before batctl throughput_override

### DIFF
--- a/patches/batman-v-wired-tpo.patch
+++ b/patches/batman-v-wired-tpo.patch
@@ -7,6 +7,6 @@ index 00000000..75888537
 +#!/bin/sh
 +
 +if [ "$IFNAME" = "vx_mesh_lan" ] || [ "$IFNAME" = "vx_mesh_wan" ] || [ "$IFNAME" = "mesh-vpn" ]; then
-+        sleep 1;
++        sleep 3;
 +        batctl hardif $IFNAME throughput_override 1000mbit;
 +fi


### PR DESCRIPTION
On some devices it may take more than a second, before a new interface is registered in BATMAN, so increasing the timeout helps to avoid wired mesh, where throughput is not set correctly. However using "sleep" is a bad idea, there should be a better hook to set the throughput override, when BATMAN is ready to, but I couldn't find it yet.