### PR TITLE
Added: ffmuc-eol-ssid package

### DIFF
--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -170,6 +170,11 @@ PKGS_TLS = PackageList('TLS', [
 ])
 pkglists.append(PKGS_TLS)
 
+PKGS_EOL = PackageList('EOL', [
+    'ffmuc-eol-ssid'
+])
+pkglists.append(PKGS_EOL)
+
 #
 # package assignment
 #
@@ -259,6 +264,10 @@ for target in ['ar71xx-nand', 'ipq40xx-generic', 'ipq806x-generic', 'lantiq-xway
 		add_pkglist(PKGS_TLS)
 
 targets.get('mpc85xx-p1020').add_pkglist(PKGS_TLS)
+
+for target in ['ar71xx-tiny', 'ramips-rt305x']:
+    targets.get(target). \
+        add_pkglist(PKGS_EOL)
 
 for target in ['brcm2708-bcm2708', 'brcm2708-bcm2709', 'brcm2708-bcm2710']:
 	targets.get(target). \

--- a/modules
+++ b/modules
@@ -14,7 +14,7 @@ PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
 
 ##	PACKAGES_FFMUC_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=cbacdb48946e32b95a8a07ccd31e7d4363e84ab8
+PACKAGES_FFMUC_COMMIT=b90c1e9d31cfd6d1d4a1ad3c428ea685bee13dd4
 
 ##  PACKAGES_FFMUC_BRANCH
 #   the branch to check out

--- a/site.mk
+++ b/site.mk
@@ -192,6 +192,12 @@ EXCLUDE_TLS := \
 	-ca-bundle \
 	-libustream-openssl
 
+INCLUDE_EOL := \
+    ffmuc-eol-ssid
+
+EXCLUDE_EOL := \
+    -ffmuc-eol-ssid
+
 ifeq ($(GLUON_TARGET),ar71xx-generic)
 	GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
 
@@ -256,8 +262,10 @@ ifeq ($(GLUON_TARGET),ar71xx-nand)
 
 endif
 
-# no pkglists for target ar71xx-tiny
+ifeq ($(GLUON_TARGET),ar71xx-tiny)
+    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
+endif
 
 ifeq ($(GLUON_TARGET),ath79-generic)
 	GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
@@ -346,8 +354,10 @@ ifeq ($(GLUON_TARGET),ramips-mt76x8)
 	GLUON_tp-link-tl-wr841n-v13_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
 endif
 
-# no pkglists for target ramips-rt305x
+ifeq ($(GLUON_TARGET),ramips-rt305x)
+    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
+endif
 
 ifeq ($(GLUON_TARGET),sunxi-cortexa7)
 	GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
@@ -370,4 +380,3 @@ ifeq ($(GLUON_TARGET),x86-geode)
 endif
 
 # no pkglists for target x86-legacy
-


### PR DESCRIPTION
I've added the ffmuc-eol-ssid package to the site.mk as well as to the genpkglist script.

Cheers 😄 

//EDIT by @krombel: Requires https://github.com/freifunkMUC/gluon-packages/pull/19