### PR TITLE
Remove "wireguard" from autoupdater branch list

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -53,25 +53,6 @@
     enabled = 1,
     branch = 'experimental',
     branches = {
-      wireguard = {
-        name = 'wireguard',
-        mirrors = {
-          'http://firmware.ffmuc.net/wireguard/sysupgrade',
-          'http://5.1.66.255/wireguard/sysupgrade',
-          'http://185.150.99.255/wireguard/sysupgrade',
-          'http://[2001:678:e68:f000::]/wireguard/sysupgrade',
-          'http://[2001:678:ed0:f000::]/wireguard/sysupgrade',
-        },
-        good_signatures = 1,
-        pubkeys = {
-          '6dcfc670a4150e16962c1852066669d9b337f168d0f6a863ed930968c2f047eb', -- awlnx
-          'dc44c9810a0470b2de63990128dbae392a836f4385d23e57eb72880ea8fbcf16', -- django
-          '5700c7a266d80aa1c6c33f29835a7b200bdd500e88ee86c0a63e24a0023364f6', -- krombel
-          '216a34d34a15688e127d8d90e6c57587aa8c682b0648322f68338487657fd5ff', -- lukesix
-          '2a74ed02120a7d48bb2dc9be988b3480ed99844054b3d7f3e5d3df27d19d814b', -- ole
-          '56c4201f6ce2994678b0142e19099dd28d6ed17775d35ca9a7f12d9235890ffc', -- chris
-        },
-      },
       stable = {
         name = 'stable',
         mirrors = {


### PR DESCRIPTION
"wireguard" Firmware is obsolete, it should no longer appear in the autoupdater selection in config mode