### PR TITLE
Update gluon-packages to include latest fix

### DIFF
--- a/modules
+++ b/modules
@@ -14,7 +14,7 @@ PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
 
 ##	PACKAGES_FFMUC_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=6b5cee39ff6171ad288baf9f7224ec27e1cadaa7
+PACKAGES_FFMUC_COMMIT=0b318700087787b9ec121f821b4ddae923433f41
 
 ##  PACKAGES_FFMUC_BRANCH
 #   the branch to check out


### PR DESCRIPTION
Forgot to update package name in the Makefile of ffmuc-autoupgrade-wireguard2experimental