### PR TITLE
Remove autoupdater info for wireguard in uci configuration

### DIFF
--- a/modules
+++ b/modules
@@ -14,7 +14,7 @@ PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
 
 ##	PACKAGES_FFMUC_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=0b318700087787b9ec121f821b4ddae923433f41
+PACKAGES_FFMUC_COMMIT=cbacdb48946e32b95a8a07ccd31e7d4363e84ab8
 
 ##  PACKAGES_FFMUC_BRANCH
 #   the branch to check out


### PR DESCRIPTION
Not just change the autoupdater branch, but also remove obsolete autoupdater information from the configuration, see https://github.com/freifunkMUC/gluon-packages/commit/cbacdb48946e32b95a8a07ccd31e7d4363e84ab8