### PR TITLE
Create manifests for all autoupdater branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ GLUON_TARGETS ?= \
 	x86-geode \
 	x86-legacy
 
+GLUON_AUTOUPDATER_BRANCH := stable
+
 ifneq (,$(shell git describe --exact-match --tags 2>/dev/null))
-	GLUON_BRANCH := stable
+	GLUON_AUTOUPDATER_ENABLED := 1
 	GLUON_RELEASE := $(shell git describe --tags 2>/dev/null)
 else
-	GLUON_BRANCH := experimental
+	GLUON_AUTOUPDATER_ENABLED := 0
 	EXP_FALLBACK = $(shell date '+%Y%m%d%H')
 	BUILD_NUMBER ?= $(EXP_FALLBACK)
 	GLUON_RELEASE := $(shell git describe --tags | cut -d- -f1)~exp$(BUILD_NUMBER)
@@ -45,7 +47,8 @@ JOBS ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)
 
 GLUON_MAKE := ${MAKE} -j ${JOBS} -C ${GLUON_BUILD_DIR} \
 	GLUON_RELEASE=${GLUON_RELEASE} \
-	GLUON_BRANCH=${GLUON_BRANCH}
+	GLUON_AUTOUPDATER_BRANCH=${GLUON_AUTOUPDATER_BRANCH} \
+	GLUON_AUTOUPDATER_ENABLED=${GLUON_AUTOUPDATER_ENABLED}
 
 all: info
 	${MAKE} manifest
@@ -54,7 +57,7 @@ info:
 	@echo
 	@echo '#########################'
 	@echo '# FFMUC Firmware build'
-	@echo '# Building release ${GLUON_RELEASE} for branch ${GLUON_BRANCH}'
+	@echo '# Building release ${GLUON_RELEASE} for branch ${GLUON_AUTOUPDATER_BRANCH}'
 	@echo
 
 build: gluon-prepare
@@ -64,11 +67,13 @@ build: gluon-prepare
 	done
 
 manifest: build
-	${GLUON_MAKE} manifest
+	for branch in experimental testing stable; do \
+		${GLUON_MAKE} manifest GLUON_AUTOUPDATER_BRANCH=$$branch;\
+	done
 	mv ${GLUON_BUILD_DIR}/output .
 
 sign: manifest
-	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} output/images/sysupgrade/${GLUON_BRANCH}.manifest
+	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} output/images/sysupgrade/${GLUON_AUTOUPDATER_BRANCH}.manifest
 
 ${GLUON_BUILD_DIR}:
 	git clone ${GLUON_GIT_URL} ${GLUON_BUILD_DIR}


### PR DESCRIPTION
Adapt makefile to use GLUON_AUTOUPDATER_ENABLED and GLUON_AUTOUPDATER_BRANCH and create manifests for all of our autoupdater branches