### PR TITLE
Run the CI for PRs

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - v*
+  pull_request:
 
 jobs:
   build_firmware:
@@ -24,13 +25,9 @@ jobs:
           remove-haskell: 'true'
       - name: Checkout
         uses: actions/checkout@master
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - name: Set tag
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo ::set-output name=tag::${GITHUB_BASE_REF:-${GITHUB_REF#refs/*/}}
       - name: Initialization environment
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -40,7 +37,7 @@ jobs:
       - name: build target ${{ matrix.target }}
         id: compile
         run: |
-          git checkout -b patched && git checkout ${{ steps.extract_branch.outputs.branch }}
+          git checkout -b patched ${GITHUB_SHA}
           make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} GLUON_RELEASE=${{ steps.vars.outputs.tag }} V=s
           echo "::set-output name=status::success"
       - name: Upload firmware ${{ matrix.target }}
@@ -53,6 +50,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     needs: build_firmware
+    if: github.event_name != 'pull_request'
     outputs:
           output1: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -74,6 +72,7 @@ jobs:
         target: [ath79-generic, ath79-nand, bcm27xx-bcm2708, bcm27xx-bcm2709, bcm27xx-bcm2710, ipq40xx-generic, ipq806x-generic, lantiq-xway, lantiq-xrx200, mediatek-mt7622, mpc85xx-p1010, mpc85xx-p1020, mvebu-cortexa9, ramips-mt7620, ramips-mt7621, ramips-mt76x8, ramips-rt305x, rockchip-armv8, sunxi-cortexa7, x86-64, x86-generic, x86-geode, x86-legacy]
     runs-on: ubuntu-latest
     needs: create_release
+    if: github.event_name != 'pull_request'
     steps:
       - name: Download Artifact ${{ matrix.target }}
         uses: actions/download-artifact@v2
@@ -83,7 +82,7 @@ jobs:
       - name: Create ${{ matrix.target }}_output.tar.gz
         run: tar zcvf ${{ matrix.target }}_output.tar.gz ${{ matrix.target }}_output
       - name: Upload Release Asset ${{ matrix.target }}
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -8,11 +8,23 @@ on:
   pull_request:
 
 jobs:
+  generate_target_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      target_json: ${{ steps.set_target.outputs.target }}
+    steps:
+    - name: Set target matrix
+      id: set_target
+      shell: bash
+      run: |
+        target_list="[\"ath79-generic\", \"ath79-nand\", \"bcm27xx-bcm2708\", \"bcm27xx-bcm2709\", \"bcm27xx-bcm2710\", \"ipq40xx-generic\", \"ipq806x-generic\", \"lantiq-xway\", \"lantiq-xrx200\", \"mediatek-mt7622\", \"mpc85xx-p1010\", \"mpc85xx-p1020\", \"mvebu-cortexa9\", \"ramips-mt7620\", \"ramips-mt7621\", \"ramips-mt76x8\", \"ramips-rt305x\", \"rockchip-armv8\", \"sunxi-cortexa7\", \"x86-64\", \"x86-generic\", \"x86-geode\", \"x86-legacy\"]"
+        echo ::set-output name=target::{\"target\": $(echo $target_list)}\"
+
   build_firmware:
+    needs: generate_target_matrix
     strategy:
       fail-fast: false
-      matrix:
-        target: [ath79-generic, ath79-nand, bcm27xx-bcm2708, bcm27xx-bcm2709, bcm27xx-bcm2710, ipq40xx-generic, ipq806x-generic, lantiq-xway, lantiq-xrx200, mediatek-mt7622, mpc85xx-p1010, mpc85xx-p1020, mvebu-cortexa9, ramips-mt7620, ramips-mt7621, ramips-mt76x8, ramips-rt305x, rockchip-armv8, sunxi-cortexa7, x86-64, x86-generic, x86-geode, x86-legacy]
+      matrix: ${{ fromJson(needs.generate_target_matrix.outputs.target_json) }}
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -68,10 +80,9 @@ jobs:
   upload_release:
     strategy:
       fail-fast: false
-      matrix:
-        target: [ath79-generic, ath79-nand, bcm27xx-bcm2708, bcm27xx-bcm2709, bcm27xx-bcm2710, ipq40xx-generic, ipq806x-generic, lantiq-xway, lantiq-xrx200, mediatek-mt7622, mpc85xx-p1010, mpc85xx-p1020, mvebu-cortexa9, ramips-mt7620, ramips-mt7621, ramips-mt76x8, ramips-rt305x, rockchip-armv8, sunxi-cortexa7, x86-64, x86-generic, x86-geode, x86-legacy]
+      matrix: ${{ fromJson(needs.generate_target_matrix.outputs.target_json) }}
     runs-on: ubuntu-latest
-    needs: create_release
+    needs: [ create_release, generate_target_matrix ]
     if: github.event_name != 'pull_request'
     steps:
       - name: Download Artifact ${{ matrix.target }}

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -37,9 +37,8 @@ jobs:
           remove-haskell: 'true'
       - name: Checkout
         uses: actions/checkout@master
-      - name: Set tag
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_BASE_REF:-${GITHUB_REF#refs/*/}}
+        with:
+          fetch-depth: 0
       - name: Initialization environment
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -50,7 +49,7 @@ jobs:
         id: compile
         run: |
           git checkout -b patched ${GITHUB_SHA}
-          make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} GLUON_RELEASE=${{ steps.vars.outputs.tag }} V=s
+          make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} V=s
           echo "::set-output name=status::success"
       - name: Upload firmware ${{ matrix.target }}
         uses: actions/upload-artifact@master


### PR DESCRIPTION
This PR enables Github Actions for future PRs to build images, but with a reduced set of commonly used targets (R6120, EX6150v2, FB 4040, ...).
The change to the CI should help avoid merging PRs which are non-functional and also allow to download and test of the resulting firmware images even before the PR has been merged.
The PR image artifacts follow the [default versioning scheme](https://github.com/freifunkMUC/site-ffm/blob/c401dc063e9a40d56823b26f0f3f6eebda5eec17/Makefile#L40-L42), e.g. `v2021.6.6~next2021080117`.

While this PR had to do modify some parts of the existing Tag-based release code, it does not create any functional change to it.

Here are example runs for a:
* tag-triggered Actions run: https://github.com/grische/site-ffm/actions/runs/1087511249
  and its release: https://github.com/grische/site-ffm/releases/tag/v1970.8
* PR-triggered Actions run: https://github.com/grische/site-ffm/actions/runs/1087510526