### PR TITLE
Updated to v2021.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2021.1
+GLUON_GIT_REF := v2021.1.1
 
 PATCH_DIR := ${GLUON_BUILD_DIR}/site/patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/site.mk
+++ b/site.mk
@@ -48,7 +48,7 @@ GLUON_SITE_PACKAGES := \
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := v2021.6.0~exp$(shell date '+%Y%m%d%H')
+DEFAULT_GLUON_RELEASE := v2021.8.0~exp$(shell date '+%Y%m%d%H')
 
 # Variables set with ?= can be overwritten from the command line
 


### PR DESCRIPTION
Release: https://github.com/freifunk-gluon/gluon/releases/tag/v2021.1.1

Changelog: https://gluon.readthedocs.io/en/v2021.1.1/releases/v2021.1.1.html