### PR TITLE
Remove wireguard2experimental

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -37,7 +37,6 @@ GLUON_SITE_PACKAGES := \
 	ffho-autoupdater-wifi-fallback \
 	ffho-web-ap-timer \
 	ffmuc-simple-radv-filter \
-	ffmuc-autoupgrade-wireguard2experimental \
 	iptables \
 	iwinfo \
 	respondd-module-airtime


### PR DESCRIPTION
As all nodes have been updated and wireguard branch is removed, the updater script can be removed again.

Closes #137