### PR TITLE
Set a defined outdoor_chanlist for wifi5

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -26,6 +26,7 @@
 
   wifi5 = {
     channel = 44,
+    outdoor_chanlist = '100-140',
     mesh = {
       mcast_rate = 12000,
     },


### PR DESCRIPTION
Without this option a node configured as outdoor may use channels in the
SRD-Band (149 to 173) on 5 GHz which allow only very limited transmit
power and thus have severely reduced covering range.

Channels 100 to 140 are permitted outdoor channels for 5 GHz in Germany
so use these.

Related gluon documentation:
https://gluon.readthedocs.io/en/latest/user/site.html#user-site-wifi5