### PR TITLE
Delete only the contents of ./output/ during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ manifest: build
 	for branch in next experimental testing stable; do \
 		${GLUON_MAKE} manifest GLUON_AUTOUPDATER_BRANCH=$$branch;\
 	done
-	mv ${GLUON_BUILD_DIR}/output .
+	mv -f ${GLUON_BUILD_DIR}/output/* ./output/
 
 sign: manifest
 	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} output/images/sysupgrade/${GLUON_AUTOUPDATER_BRANCH}.manifest
@@ -110,6 +110,7 @@ gluon-clean:
 	rm -rf ${GLUON_BUILD_DIR}
 
 output-clean:
-	rm -rf output
+	mkdir -p output/
+	rm -rf output/*
 
 clean: gluon-clean output-clean


### PR DESCRIPTION
Removing the output folder is causing problems if the folder is mounted.

In my case, I am building it with a Ubuntu Docker container and therefore I mount both output and gluon-build:
```bash
docker run --rm -v ${PWD}/output:/site-ffm/output/ -v ${PWD}/gluon-build:/site-ffm/gluon-build site-ffm:pr154 bash -c 'make'
```

This is only possible if the ./output folder is never moved or overwritten, hence this PR.