### PR TITLE
Move build dependencies into separate script

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -39,12 +39,9 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - name: Initialization environment
-        env:
-          DEBIAN_FRONTEND: noninteractive
+      - name: Install build dependencies
         run: |
-          sudo -E apt-get update
-          sudo -E apt-get -y install build-essential asciidoc binutils bzip2 gawk gettext git libncurses5-dev libz-dev patch python2.7 python3 unzip zlib1g-dev lib32gcc1 libc6-dev-i386 subversion flex uglifyjs gcc-multilib g++-multilib p7zip p7zip-full msmtp libssl-dev texinfo libglib2.0-dev xmlto qemu-utils upx libelf-dev autoconf automake libtool autopoint device-tree-compiler antlr3 gperf
+          sudo -E ./install_build_dependencies.sh
       - name: build target ${{ matrix.target }}
         id: compile
         run: |

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+set -eEux
+
+# Verify that the script is running in Ubuntu
+. /etc/lsb-release
+if [ "$DISTRIB_ID" != "Ubuntu" ]; then
+    echo "Error: This script only works in Ubuntu"
+    exit 1
+fi
+
+# Avoid tzdata from asking which timezone to choose
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+
+# Install build environment
+apt-get -y --no-install-recommends install \
+    antlr3 \
+    asciidoc \
+    autoconf \
+    automake \
+    autopoint \
+    binutils \
+    build-essential \
+    bzip2 \
+    device-tree-compiler \
+    flex \
+    g++-multilib \
+    gawk \
+    gcc-multilib \
+    gettext \
+    git \
+    gperf \
+    lib32gcc1 \
+    libc6-dev-i386 \
+    libelf-dev \
+    libglib2.0-dev \
+    libncurses5-dev \
+    libssl-dev \
+    libtool \
+    libz-dev \
+    msmtp \
+    p7zip \
+    p7zip-full \
+    patch \
+    python2.7 \
+    python3 \
+    qemu-utils \
+    subversion \
+    texinfo \
+    uglifyjs \
+    unzip \
+    upx \
+    wget \
+    xmlto \
+    zlib1g-dev

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -14,44 +14,24 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 
+# ca-certificates required for Github git cloning
+apt-get -y --no-install-recommends install ca-certificates
+
 # Install build environment
 apt-get -y --no-install-recommends install \
-    antlr3 \
-    asciidoc \
-    autoconf \
-    automake \
-    autopoint \
-    binutils \
-    build-essential \
+    bash \
     bzip2 \
-    device-tree-compiler \
-    flex \
-    g++-multilib \
+    diffutils \
+    file \
+    g++ \
     gawk \
-    gcc-multilib \
-    gettext \
+    gcc \
     git \
-    gperf \
-    lib32gcc1 \
-    libc6-dev-i386 \
-    libelf-dev \
-    libglib2.0-dev \
     libncurses5-dev \
-    libssl-dev \
-    libtool \
-    libz-dev \
-    msmtp \
-    p7zip \
-    p7zip-full \
+    make \
     patch \
-    python2.7 \
-    python3 \
-    qemu-utils \
-    subversion \
-    texinfo \
-    uglifyjs \
+    perl \
+    python2 \
+    tar \
     unzip \
-    upx \
-    wget \
-    xmlto \
-    zlib1g-dev
+    wget


### PR DESCRIPTION
This script moves the build-time dependencies from the Github Actions workflow into a separate script, so it can be shared across other Ubuntu based builders.

At the same time, I also removed all packages in a separate commit which are not required by the worker to run a `make`. This reduces the size of the installation from ~1GB to ~400MB (measured by running the install script before and after cleanup in a `ubuntu:20.04` Docker container).