### PR TITLE
Move build dependencies into separate script for next

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -39,12 +39,9 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - name: Initialization environment
-        env:
-          DEBIAN_FRONTEND: noninteractive
+      - name: Install build dependencies
         run: |
-          sudo -E apt-get update
-          sudo -E apt-get -y install build-essential asciidoc binutils bzip2 gawk gettext git libncurses5-dev libz-dev patch python2.7 python3 unzip zlib1g-dev lib32gcc1 libc6-dev-i386 subversion flex uglifyjs gcc-multilib g++-multilib p7zip p7zip-full msmtp libssl-dev texinfo libglib2.0-dev xmlto qemu-utils upx libelf-dev autoconf automake libtool autopoint device-tree-compiler antlr3 gperf
+          sudo -E ./install_build_dependencies.sh
       - name: build target ${{ matrix.target }}
         id: compile
         run: |

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+set -eEux
+
+# Verify that the script is running in Ubuntu
+. /etc/lsb-release
+if [ "$DISTRIB_ID" != "Ubuntu" ]; then
+    echo "Error: This script only works in Ubuntu"
+    exit 1
+fi
+
+# Avoid tzdata from asking which timezone to choose
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+
+# Install build environment
+apt-get -y --no-install-recommends install \
+    antlr3 \
+    asciidoc \
+    autoconf \
+    automake \
+    autopoint \
+    binutils \
+    build-essential \
+    bzip2 \
+    device-tree-compiler \
+    flex \
+    g++-multilib \
+    gawk \
+    gcc-multilib \
+    gettext \
+    git \
+    gperf \
+    lib32gcc1 \
+    libc6-dev-i386 \
+    libelf-dev \
+    libglib2.0-dev \
+    libncurses5-dev \
+    libssl-dev \
+    libtool \
+    libz-dev \
+    msmtp \
+    p7zip \
+    p7zip-full \
+    patch \
+    python2.7 \
+    python3 \
+    qemu-utils \
+    subversion \
+    texinfo \
+    uglifyjs \
+    unzip \
+    upx \
+    wget \
+    xmlto \
+    zlib1g-dev

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -33,6 +33,7 @@ apt-get -y --no-install-recommends install \
     patch \
     perl \
     python3 \
+    qemu-utils \
     rsync \
     tar \
     unzip \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -14,44 +14,26 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 
+# ca-certificates required for Github git cloning
+apt-get -y --no-install-recommends install ca-certificates
+
 # Install build environment
 apt-get -y --no-install-recommends install \
-    antlr3 \
-    asciidoc \
-    autoconf \
-    automake \
-    autopoint \
-    binutils \
-    build-essential \
+    bash \
     bzip2 \
-    device-tree-compiler \
-    flex \
-    g++-multilib \
+    curl \
+    diffutils \
+    file \
+    g++ \
     gawk \
-    gcc-multilib \
-    gettext \
+    gcc \
     git \
-    gperf \
-    lib32gcc1 \
-    libc6-dev-i386 \
-    libelf-dev \
-    libglib2.0-dev \
     libncurses5-dev \
-    libssl-dev \
-    libtool \
-    libz-dev \
-    msmtp \
-    p7zip \
-    p7zip-full \
+    make \
     patch \
-    python2.7 \
+    perl \
     python3 \
-    qemu-utils \
-    subversion \
-    texinfo \
-    uglifyjs \
+    rsync \
+    tar \
     unzip \
-    upx \
-    wget \
-    xmlto \
-    zlib1g-dev
+    wget


### PR DESCRIPTION
This PR is similar to https://github.com/freifunkMUC/site-ffm/pull/155 but with a different list of build dependencies.
The size of the docker container here is also ~420MB after the update and ~1GB before.
The differences between stable (red) and next (green) are:
```diff
diff --git a/install_build_dependencies.sh b/install_build_dependencies.sh
index 2d44437..879b853 100755
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -21,6 +21,7 @@ apt-get -y --no-install-recommends install ca-certificates
 apt-get -y --no-install-recommends install \
     bash \
     bzip2 \
+    curl \
     diffutils \
     file \
     g++ \
@@ -31,7 +32,8 @@ apt-get -y --no-install-recommends install \
     make \
     patch \
     perl \
-    python2 \
+    python3 \
+    rsync \
     tar \
     unzip \
     wget
```

I verified that they are all required by running the build process in an `ubuntu:20.04` container, similar to the previous PR.