### PR TITLE
Include ffmuc-autoupdater-next to set autoupdater branch correctly

### DIFF
--- a/modules
+++ b/modules
@@ -14,7 +14,7 @@ PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
 
 ##	PACKAGES_FFMUC_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=cbacdb48946e32b95a8a07ccd31e7d4363e84ab8
+PACKAGES_FFMUC_COMMIT=f150bdd0398b3b2585b18c4495a671cd54733334
 
 ##  PACKAGES_FFMUC_BRANCH
 #   the branch to check out

--- a/site.mk
+++ b/site.mk
@@ -21,9 +21,10 @@ GLUON_SITE_PACKAGES := \
 	ffho-ap-timer \
 	ffho-web-ap-timer \
 	ffmuc-simple-radv-filter \
+	ffmuc-gluon-mesh-vpn-wireguard-vxlan \
+	ffmuc-autoupdater-next \
 	iwinfo \
 	iptables \
-	ffmuc-gluon-mesh-vpn-wireguard-vxlan \
 	respondd-module-airtime
 
 DEFAULT_GLUON_RELEASE := v2021.6.0~exp$(shell date '+%Y%m%d%H')


### PR DESCRIPTION
Devices running next firmware should have autoupdater branch also set to next. Devices for which no stable firmware is available yet should stay up to date, devices for which stable firmware exists should not downgrade automatically, as it is not supported and is causing network configuration issues.