### PR TITLE
Updated ffmuc-eol-ssid to replace the SSID

### DIFF
--- a/modules
+++ b/modules
@@ -14,7 +14,7 @@ PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
 
 ##	PACKAGES_FFMUC_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=b90c1e9d31cfd6d1d4a1ad3c428ea685bee13dd4
+PACKAGES_FFMUC_COMMIT=403526c6881f62d7258292b9b6170dc4124c4078
 
 ##  PACKAGES_FFMUC_BRANCH
 #   the branch to check out


### PR DESCRIPTION
Instead of adding an additional SSID to the router, "muenchen.freifunk.net/segment" is now replaced with "bitte-router-erneuern.ffmuc.net". A configuration option has been added to be able to disable this behaviour.

Actual change here: https://github.com/freifunkMUC/gluon-packages/commit/403526c6881f62d7258292b9b6170dc4124c4078

//EDIT @krombel add link to referencing commit