### PR TITLE
Updated modules to include wireguard package fix

### DIFF
--- a/modules
+++ b/modules
@@ -26,7 +26,7 @@ PACKAGES_WIREGUARD_REPO=https://github.com/freifunkMUC/community-packages.git
 
 ##	PACKAGES_WIREGUARD_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_WIREGUARD_COMMIT=0273c43797600df19e90677b1c09364f6172f8cc
+PACKAGES_WIREGUARD_COMMIT=876a8d8f9805281e95815b7d2d5a4d997a393dc6
 
 ##  PACKAGES_WIREGUARD_BRANCH
 #   the branch to check out


### PR DESCRIPTION
https://github.com/freifunkMUC/community-packages/commit/876a8d8f9805281e95815b7d2d5a4d997a393dc6
Only add ip6tables rule, if not set already
For each reconnection checkuplink was adding an additional entry to the INPUT chain in ip6tables. In case a node does not have WAN connection, but accidentally enabled mesh over VPN, this adding 1440 rules per day or about 40k rules within a month.