### PR TITLE
Bump to latest Gluon master to fix CVE-2022-24884

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 9ec4abd0435b3291cce3674137f7506a10879229
+GLUON_GIT_REF := 204f7e56e31a5e114d594582bbaba5b751770e98
 
 PATCH_DIR := ${GLUON_BUILD_DIR}/site/patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
See https://github.com/freifunk-gluon/gluon/security/advisories/GHSA-xqhj-fmc7-f8mv