### PR TITLE
Bump gluon to latest OpenWrt 21.02 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 9ec4abd0435b3291cce3674137f7506a10879229
+GLUON_GIT_REF := f54c0e789fbc4904d9d44635db2d8f55166011f7
 
 PATCH_DIR := ${GLUON_BUILD_DIR}/site/patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
Updating `next` to the latest gluon upstream version based on OpenWRT 21.02