### PR TITLE
Add official Fritzbox 7520 support [next]

### DIFF
--- a/patches/targets-fritz-box-7520.patch
+++ b/patches/targets-fritz-box-7520.patch
@@ -1,0 +1,12 @@
+diff --git a/targets/ipq40xx-generic b/targets/ipq40xx-generic
+index e3fc746b..d5194a37 100644
+--- a/targets/ipq40xx-generic
++++ b/targets/ipq40xx-generic
+@@ -50,6 +50,7 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
+ 
+ device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
+ 	factory = false,
++	aliases = {'avm-fritz-box-7520'},
+ })
+ 
+ device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {


### PR DESCRIPTION
Officially added to OpenWRT 22.03
https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=cb6f4be13703f0224fc462caaeac14e725c72986

But it works with the 7530 image already.