### PR TITLE
Add building instructions with Docker

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,0 +1,4 @@
+FROM ubuntu:20.04
+
+ADD ./scripts/install_build_dependencies.sh /
+RUN /install_build_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ git checkout -b patched && git checkout stable
 make
 ```
 
+### Containerised building
+
+As the CI is using Ubuntu, only the Ubuntu dependencies are being tracked. To simplify building on other distros, containerised building is also possible:
+```sh
+docker build -t site-ffm -f Dockerfile_build .
+```
+This will build the build Docker image. With the following export, the Makefile will then use the repo for building but will run inside an Ubuntu container.\
+**Note**: If the working directory is a git worktree, add a volume mount for the main git folder.
+```sh
+docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-next make
+```
+
+#### Example
+Full command for a [lantiq-xrx200](https://github.com/freifunk-gluon/gluon/blob/v2022.1/targets/lantiq-xrx200) build:
+
+```sh
+mkdir -p logs
+docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-next make V=s BROKEN=1 GLUON_TARGETS=lantiq-xrx200 |& tee logs/buildtest_lantiq-xrx200_$(date --iso=s).log
+```
+
 ## Further Resources
 
 This firmware is based on [Gluon](https://gluon.readthedocs.io/en/v2021.1/).


### PR DESCRIPTION
~~The caveat with this build is, that it ignores variables after "make" (e.g. the `GLUON_TARGET` in `make GLUON_TARGET=lantiq-xrx200`)~~

The new PR adds a Dockerfile and the corresponding command to build via Docker. Not as nice as initially planned, but without the drawbacks.

This has been tested on my local system and works like a charm.