### PR TITLE
[next] Fix overriding the main git remote by accident

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ info:
 	@echo '# Building release ${GLUON_RELEASE} for branch ${GLUON_AUTOUPDATER_BRANCH}'
 	@echo
 
-build: gluon-prepare
+build: gluon-prepare output-clean
 	for target in ${GLUON_TARGETS}; do \
 		echo ""Building target $$target""; \
 		${GLUON_MAKE} download all GLUON_TARGET="$$target"; \
@@ -88,7 +88,7 @@ gluon-update: | ${GLUON_BUILD_DIR}/.git
 	cd ${GLUON_BUILD_DIR} && git reset --hard FETCH_HEAD
 	cd ${GLUON_BUILD_DIR} && git clean -fd
 
-gluon-prepare: gluon-update output-clean
+gluon-prepare: gluon-update
 	make gluon-patch
 	ln -sfT .. ${GLUON_BUILD_DIR}/site
 	${GLUON_MAKE} update


### PR DESCRIPTION
In case the gluon-build folder exists and does not contain a .git directory (or file) the following command "git remote set-url origin" will override the git remote of the "main" folder/directory.

Avoiding this by checking explicitely for the .git directory inside gluon-build instead of just checking for the folder's existence.