### PR TITLE
[stable] Fix overriding the main git remote by accident

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ manifest: build
 sign: manifest
 	${GLUON_BUILD_DIR}/contrib/sign.sh ${SECRET_KEY_FILE} output/images/sysupgrade/${GLUON_AUTOUPDATER_BRANCH}.manifest
 
-${GLUON_BUILD_DIR}:
+${GLUON_BUILD_DIR}/.git:
 	git clone ${GLUON_GIT_URL} ${GLUON_BUILD_DIR}
 
-gluon-prepare: output-clean ${GLUON_BUILD_DIR}
+gluon-prepare: output-clean ${GLUON_BUILD_DIR}/.git
 	cd ${GLUON_BUILD_DIR} \
 		&& git remote set-url origin ${GLUON_GIT_URL} \
 		&& git fetch origin \
@@ -109,6 +109,7 @@ gluon-patch:
 
 gluon-clean:
 	rm -rf ${GLUON_BUILD_DIR}
+	mkdir -p ${GLUON_BUILD_DIR}
 
 output-clean:
 	mkdir -p output/


### PR DESCRIPTION
In case the gluon-build folder exists and does not contain a .git directory (or file) the following command "git remote set-url origin" will override the git remote of the "main" folder/directory.

Avoiding this by checking explicitely for the .git directory inside gluon-build instead of just checking for the folder's existence.