### PR TITLE
Simplify patching and move it into separate script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
 GLUON_GIT_REF := f54c0e789fbc4904d9d44635db2d8f55166011f7
 
-PATCH_DIR := ${GLUON_BUILD_DIR}/site/patches
+PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 
 GLUON_TARGETS ?= \
@@ -83,27 +83,12 @@ gluon-prepare: output-clean ${GLUON_BUILD_DIR}
 		&& git fetch origin \
 		&& git checkout -q --force ${GLUON_GIT_REF} \
 		&& git clean -fd;
-	ln -sfT .. ${GLUON_BUILD_DIR}/site
 	make gluon-patch
+	ln -sfT .. ${GLUON_BUILD_DIR}/site
 	${GLUON_MAKE} update
 
 gluon-patch:
-	echo "Applying Patches ..."
-	(cd ${GLUON_BUILD_DIR})
-			if [ `git branch --list patched` ]; then \
-				(git branch -D patched) \
-			fi
-	(cd ${GLUON_BUILD_DIR}; git checkout -B patching)
-	if [ -d "${GLUON_BUILD_DIR}/site/patches" -a "${GLUON_BUILD_DIR}/site/patches/*.patch" ]; then \
-		(cd ${GLUON_BUILD_DIR}; git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn --verbose site/patches/*.patch) || ( \
-			cd ${GLUON_BUILD_DIR}; \
-			git clean -fd; \
-			git checkout -B patched; \
-			git branch -D patching; \
-			exit 1 \
-		) \
-	fi
-	(cd ${GLUON_BUILD_DIR}; git branch -M patched)
+	scripts/apply_patches.sh ${GLUON_BUILD_DIR} ${PATCH_DIR}
 
 gluon-clean:
 	rm -rf ${GLUON_BUILD_DIR}

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eEu
+set -o pipefail
+shopt -s nullglob
+
+gluon_build_dir=${1:-gluon-build}
+gluon_patch_dir="${2:-patches}"
+
+function reset_gluon_build_dir() {
+    # Make sure we are in the correct folder
+    if [[ ! $(pwd) =~ .*${gluon_build_dir} ]]; then
+        echo "Resetting environment in the wrong folder. Aborting."
+        return 1
+    fi
+    echo "Resetting environment."
+
+    # Reset all files known to git, but keep manually commited changes.
+    git checkout .
+    # Delete all files not known to git
+    git clean -dx --force
+    echo "Environment reset."
+}
+
+# Relative patches folder does not work with git-apply below. Make sure it is an absolute path.
+if [[ ! ${gluon_patch_dir} =~ ^/ ]]; then
+    gluon_patch_dir="${PWD}/${gluon_patch_dir}"
+    echo "Setting patch directory to ${gluon_patch_dir}"
+fi
+
+pushd "${gluon_build_dir}"
+
+# Check if there are any patches at all
+if ! compgen -G "${gluon_patch_dir}/*.patch" >/dev/null; then
+    echo "No patches found in ${gluon_patch_dir}/*.patch"
+    exit 1
+fi
+
+# Reset previously applied patches
+reset_gluon_build_dir
+
+# Apply all patches
+echo "Applying Patches."
+if ! git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn --verbose "${gluon_patch_dir}"/*.patch; then
+    echo "Patching failed. Inspect ${gluon_build_dir} folder for failed patches."
+    exit 1
+fi
+
+echo "Patching finished."
+popd


### PR DESCRIPTION
* Make the script idempotent (you can run it again to test patching)
* Drop the usage of git branches for patching. The branches were not used and add unncessary complexity
* Do not forcefully reset custom commits in gluon-build as part of the patching
* Reset the gluon-build environment before applying patches
* Do not reset gluon-build environment for debugging if patching failed