### PR TITLE
actions: fix missing x86-64 artifacts in releases

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -12,19 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_json: ${{ steps.set_target.outputs.target }}
+      build_target_json: ${{ steps.set_target.outputs.build_target }}
     steps:
       - name: Set target matrix
         id: set_target
         shell: bash
         run: |
-          target_list="[\"ath79-generic\", \"ath79-nand\", \"bcm27xx-bcm2708\", \"bcm27xx-bcm2709\", \"bcm27xx-bcm2710\", \"bcm27xx-bcm2711\", \"ipq40xx-generic\", \"ipq806x-generic\", \"lantiq-xway\", \"lantiq-xrx200\", \"mediatek-mt7622\", \"mpc85xx-p1010\", \"mpc85xx-p1020\", \"mvebu-cortexa9\", \"ramips-mt7620\", \"ramips-mt7621\", \"ramips-mt76x8\", \"rockchip-armv8\", \"sunxi-cortexa7\", \"x86-generic\", \"x86-geode\", \"x86-legacy\"]"
+          target_list="[\"ath79-generic\", \"ath79-nand\", \"bcm27xx-bcm2708\", \"bcm27xx-bcm2709\", \"bcm27xx-bcm2710\", \"bcm27xx-bcm2711\", \"ipq40xx-generic\", \"ipq806x-generic\", \"lantiq-xway\", \"lantiq-xrx200\", \"mediatek-mt7622\", \"mpc85xx-p1010\", \"mpc85xx-p1020\", \"mvebu-cortexa9\", \"ramips-mt7620\", \"ramips-mt7621\", \"ramips-mt76x8\", \"rockchip-armv8\", \"sunxi-cortexa7\", \"x86-64\", \"x86-generic\", \"x86-geode\", \"x86-legacy\"]"
           echo ::set-output name=target::{\"target\": $(echo $target_list)}\"
+          echo ::set-output name=build_target::{\"target\": $(echo $target_list | sed 's/, "x86-64"//')}\"
 
   build_firmware:
     needs: generate_target_matrix
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate_target_matrix.outputs.target_json) }}
+      matrix: ${{ fromJson(needs.generate_target_matrix.outputs.build_target_json) }}
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space


### PR DESCRIPTION
The change allows excluding the x86-64 target during building while still adding the x86-64 artifact to releases.

This is a follow-up of ab82dcccc45a8eb8931e2090b875ff03b76afc8b