### PR TITLE
revert gluon-mesh-batman-adv: add "gateway_tq" field to respondd statistics

### DIFF
--- a/patches/revert-gluon-mesh-batman-adv-add-gateway_tq-field-to.patch
+++ b/patches/revert-gluon-mesh-batman-adv-add-gateway_tq-field-to.patch
@@ -1,0 +1,48 @@
+From 5e0aeee419594a02482e70770c6941ccc0a12173 Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Wed, 5 Oct 2022 23:26:04 +0200
+Subject: [PATCH] Revert "gluon-mesh-batman-adv: add "gateway_tq" field to
+ respondd statistics (#2596)"
+
+This reverts commit 6df06473012ddcf6128cef728891e5891abf1556.
+---
+ package/gluon-mesh-batman-adv/src/respondd-statistics.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/package/gluon-mesh-batman-adv/src/respondd-statistics.c b/package/gluon-mesh-batman-adv/src/respondd-statistics.c
+index 86709464..c9394d87 100644
+--- a/package/gluon-mesh-batman-adv/src/respondd-statistics.c
++++ b/package/gluon-mesh-batman-adv/src/respondd-statistics.c
+@@ -63,7 +63,6 @@ struct gw_netlink_opts {
+ static const enum batadv_nl_attrs gateways_mandatory[] = {
+ 	BATADV_ATTR_ORIG_ADDRESS,
+ 	BATADV_ATTR_ROUTER,
+-	BATADV_ATTR_TQ,
+ };
+ 
+ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+@@ -74,7 +73,6 @@ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+ 	struct genlmsghdr *ghdr;
+ 	uint8_t *orig;
+ 	uint8_t *router;
+-	uint8_t tq;
+ 	struct gw_netlink_opts *opts;
+ 	char addr[18];
+ 
+@@ -102,13 +100,11 @@ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+ 
+ 	orig = nla_data(attrs[BATADV_ATTR_ORIG_ADDRESS]);
+ 	router = nla_data(attrs[BATADV_ATTR_ROUTER]);
+-	tq = nla_get_u8(attrs[BATADV_ATTR_TQ]);
+ 
+ 	sprintf(addr, "%02x:%02x:%02x:%02x:%02x:%02x",
+ 		orig[0], orig[1], orig[2], orig[3], orig[4], orig[5]);
+ 
+ 	json_object_object_add(opts->obj, "gateway", json_object_new_string(addr));
+-	json_object_object_add(opts->obj, "gateway_tq", json_object_new_int(tq));
+ 
+ 	sprintf(addr, "%02x:%02x:%02x:%02x:%02x:%02x",
+ 		router[0], router[1], router[2], router[3], router[4], router[5]);
+-- 
+2.25.1
+


### PR DESCRIPTION
This reverts
https://github.com/freifunk-gluon/gluon/commit/6df06473012ddcf6128cef728891e5891abf1556

and fixes a bug with gateway and gateway_nexthop not showing up when using Batman V. Can be tested by using the following command:

```
gluon-neighbour-info -d ::1 -r statistics
```