### PR TITLE
Fix issue with introduction of batman TQ property in respondd

### DIFF
--- a/patches/batman-v-respondd-statistics.patch
+++ b/patches/batman-v-respondd-statistics.patch
@@ -1,0 +1,38 @@
+diff --git a/package/gluon-mesh-batman-adv/src/respondd-statistics.c b/package/gluon-mesh-batman-adv/src/respondd-statistics.c
+index 86709464..a07dfdbf 100644
+--- a/package/gluon-mesh-batman-adv/src/respondd-statistics.c
++++ b/package/gluon-mesh-batman-adv/src/respondd-statistics.c
+@@ -63,7 +63,7 @@ struct gw_netlink_opts {
+ static const enum batadv_nl_attrs gateways_mandatory[] = {
+ 	BATADV_ATTR_ORIG_ADDRESS,
+ 	BATADV_ATTR_ROUTER,
+-	BATADV_ATTR_TQ,
++	BATADV_ATTR_THROUGHPUT,
+ };
+ 
+ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+@@ -74,7 +74,7 @@ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+ 	struct genlmsghdr *ghdr;
+ 	uint8_t *orig;
+ 	uint8_t *router;
+-	uint8_t tq;
++	uint32_t throughput;
+ 	struct gw_netlink_opts *opts;
+ 	char addr[18];
+ 
+@@ -102,13 +102,13 @@ static int parse_gw_list_netlink_cb(struct nl_msg *msg, void *arg)
+ 
+ 	orig = nla_data(attrs[BATADV_ATTR_ORIG_ADDRESS]);
+ 	router = nla_data(attrs[BATADV_ATTR_ROUTER]);
+-	tq = nla_get_u8(attrs[BATADV_ATTR_TQ]);
++	throughput = nla_get_u32(attrs[BATADV_ATTR_THROUGHPUT]);
+ 
+ 	sprintf(addr, "%02x:%02x:%02x:%02x:%02x:%02x",
+ 		orig[0], orig[1], orig[2], orig[3], orig[4], orig[5]);
+ 
+ 	json_object_object_add(opts->obj, "gateway", json_object_new_string(addr));
+-	json_object_object_add(opts->obj, "gateway_tq", json_object_new_int(tq));
++	json_object_object_add(opts->obj, "gateway_throughput", json_object_new_int(throughput));
+ 
+ 	sprintf(addr, "%02x:%02x:%02x:%02x:%02x:%02x",
+ 		router[0], router[1], router[2], router[3], router[4], router[5]);


### PR DESCRIPTION
Gluon introduced adding the TQ property of batman to the gateway information. As we do use BATMAN V, where a TQ property no longer exists, gateway information was dropped completely from respondd content and our status page.

This change fixes this, by using the THROUGHPUT propery instead.