### PR TITLE
Bump Gluon to latest commit to include critical security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Freifunk München Firmware Changelog
 
+## v2022.10.3
+ - Bump Gluon to latest commit to include critical security fixes for wifi stack
+ - Enable TLS on all devices
+ - Fixed autoupdater for Loco M XW
+ - Temporarily disabled autoupdater next2stable migration
+
+## v2022.10.2
+ - Bump Gluon to latest commit to include USB ethernet fix
+
 ## v2022.10.1
  - Bump Gluon to v2022.1 https://gluon.readthedocs.io/en/v2022.1.x/releases/v2022.1.html
  - Merge changes from next branch to support Gluon v2022.1/OpenWrt 22.03 into stable

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := da412471394ad212c06ea96c29c6414e06ed3f68 # branch v2022.1.x
+GLUON_GIT_REF := 183f34597903d94e9d4cd642bdc87f0adb808816 # branch v2022.1.x
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/site.mk
+++ b/site.mk
@@ -20,11 +20,11 @@ GLUON_SITE_PACKAGES := \
 	ffho-ap-timer \
 	ffho-autoupdater-wifi-fallback \
 	ffho-web-ap-timer \
-	ffmuc-autoupdater-next2stable \
 	ffmuc-mesh-vpn-wireguard-vxlan \
 	ffmuc-simple-radv-filter \
 	iwinfo \
 	respondd-module-airtime
+#	ffmuc-autoupdater-next2stable \
 
 DEFAULT_GLUON_RELEASE := v2022.10.1~exp$(shell date '+%Y%m%d%H')
 


### PR DESCRIPTION
- Latest Gluon commit contains kernel fixes for remote exploitable buffer overflow in wifi stack
- Temporarily disable autoupdater next2stable migration