### PR TITLE
ci: replace arm64 workaround with prebuilding fw

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           target_list="[\"ath79-generic\", \"ath79-nand\", \"bcm27xx-bcm2708\", \"bcm27xx-bcm2709\", \"bcm27xx-bcm2710\", \"bcm27xx-bcm2711\", \"ipq40xx-generic\", \"ipq806x-generic\", \"lantiq-xway\", \"lantiq-xrx200\", \"mediatek-mt7622\", \"mpc85xx-p1010\", \"mpc85xx-p1020\", \"mvebu-cortexa9\", \"ramips-mt7620\", \"ramips-mt7621\", \"ramips-mt76x8\", \"rockchip-armv8\", \"sunxi-cortexa7\", \"x86-64\", \"x86-generic\", \"x86-geode\", \"x86-legacy\"]"
           echo ::set-output name=target::{\"target\": $(echo $target_list)}\"
-          echo ::set-output name=build_target::{\"target\": $(echo $target_list | sed 's/, "x86-64"//')}\"
+          echo ::set-output name=build_target::{\"target\": $(echo $target_list)}\"
 
   build_firmware:
     needs: generate_target_matrix
@@ -49,34 +49,12 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo -E ./scripts/install_build_dependencies.sh
-      - name: build target ${{ matrix.target }}
-        id: compile
+      - name: pre-build without ffmuc-mesh-vpn-wireguard-vxlan (workaround for x86-64)
+        if: matrix.target == 'x86-64'
         run: |
-          git checkout -b patched ${GITHUB_SHA}
+          sed -i '/ffmuc-mesh-vpn-wireguard-vxlan/d' site.mk
           make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} V=s
-          echo "::set-output name=status::success"
-      - name: Upload firmware ${{ matrix.target }}
-        uses: actions/upload-artifact@master
-        if: steps.compile.outputs.status == 'success'
-        with:
-          name: ${{ matrix.target }}_output
-          path: ./output
-
-  build_firmware_on_arm64:
-    needs: generate_target_matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["x86-64"]
-    runs-on: "ARM64"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-      - name: Install build dependencies
-        run: |
-          sudo -E ./scripts/install_build_dependencies.sh
+          git checkout site.mk
       - name: build target ${{ matrix.target }}
         id: compile
         run: |
@@ -94,7 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_firmware
-      - build_firmware_on_arm64
     if: github.event_name != 'pull_request'
     outputs:
       output1: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
As discussed in the chat, this "should" allow us to stop using the self-hosted runner.

We need to test if the resulting x86-64 artefact is usable.