### PR TITLE
Add --tags to git fetch to make sure all Gluon tags are included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ${GLUON_BUILD_DIR}/.git: | ${GLUON_BUILD_DIR}
 	cd ${GLUON_BUILD_DIR} && git remote add origin ${GLUON_GIT_URL}
 
 gluon-update: | ${GLUON_BUILD_DIR}/.git
-	cd ${GLUON_BUILD_DIR} && git fetch origin ${GLUON_GIT_REF}
+	cd ${GLUON_BUILD_DIR} && git fetch --tags origin ${GLUON_GIT_REF}
 	cd ${GLUON_BUILD_DIR} && git reset --hard FETCH_HEAD
 	cd ${GLUON_BUILD_DIR} && git clean -fd
 


### PR DESCRIPTION
When preparation the gluon-build folder was changed from git clone to git fetch, the tags got lost. This is causing the generated fIrmware version not to incluce the gluon version correctly: "v2022.10.4 / gluon-ab1fb05+" instead of "v2022.10.4 / gluon-v2022.1.1+"