### PR TITLE
Fix TPO for vx_mesh_uplink

### DIFF
--- a/patches/batman-v-wired-tpo.patch
+++ b/patches/batman-v-wired-tpo.patch
@@ -6,7 +6,7 @@ index 00000000..75888537
 @@ -0,0 +1,6 @@
 +#!/bin/sh
 +
-+if [ "$IFNAME" = "vx_mesh_other" ] || [ "$IFNAME" = "mesh-vpn" ]; then
++if [ "$IFNAME" = "vx_mesh_uplink" ] || [ "$IFNAME" = "vx_mesh_other" ] || [ "$IFNAME" = "mesh-vpn" ]; then
 +        sleep 3;
 +        batctl hardif $IFNAME throughput_override 1000mbit;
 +fi


### PR DESCRIPTION
Gluon v2022.1.1 uses a new interface called vx_mesh_uplink, which was not yet handled correctly in our BATMAN V Patch.