### PR TITLE
Bump Gluon to v2022.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2022.1.2
+GLUON_GIT_REF := v2022.1.3
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
This fixes some critical regressions with Gluon v2022.1.2: https://gluon.readthedocs.io/en/latest/releases/v2022.1.3.html