### PR TITLE
Add support for MikroTik SXTsq 5 ac and MikroTik RouterBoard RB951Ui-2HnD

### DIFF
--- a/targets
+++ b/targets
@@ -1,10 +1,12 @@
 ath79-generic
+ath79-mikrotik
 ath79-nand
 bcm27xx-bcm2708
 bcm27xx-bcm2709
 bcm27xx-bcm2710
 bcm27xx-bcm2711
 ipq40xx-generic
+ipq40xx-mikrotik
 ipq806x-generic
 lantiq-xrx200
 lantiq-xway


### PR DESCRIPTION
These targets have been added with Gluon v2022.1