### PR TITLE
fix name for download-artifact action

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -74,7 +74,7 @@ jobs:
       - build_firmware
     if: github.event_name != 'pull_request'
     steps:
-      - name: Download Artifacts for ${{ matrix.target }}
+      - name: Download all artifacts
         uses: actions/download-artifact@v3
       - name: Display structure of artifacts
         run: ls -R


### PR DESCRIPTION
I just noticed that `${{ matrix.target }}` is invalid here. Luckily Github ignored it so far and returned an empty string.

Follow-up of 488c430e7031a9e25c1b3864bc42820e0fc3ed96