### PR TITLE
ath79-generic: drop TP-Link RE450 and RE355

### DIFF
--- a/patches/targets-drop-TP-Link-RE450-and-RE355.patch
+++ b/patches/targets-drop-TP-Link-RE450-and-RE355.patch
@@ -1,0 +1,41 @@
+From b5fb157e3b67b2d39f5b7c391ef39f0b19e4cf2e Mon Sep 17 00:00:00 2001
+From: Christian <github@grische.xyz>
+Date: Fri, 18 Aug 2023 17:02:22 +0200
+Subject: [PATCH] targets: drop TP-Link RE450 and RE355
+
+The flash size is not sufficient to host the minimal set of FFMuc packages
+---
+ targets/ath79-generic | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/targets/ath79-generic b/targets/ath79-generic
+index 2162caee..04bad914 100644
+--- a/targets/ath79-generic
++++ b/targets/ath79-generic
+@@ -445,23 +445,6 @@ device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
+ 	packages = ATH10K_PACKAGES_QCA9888,
+ })
+ 
+-device('tp-link-re355-v1', 'tplink_re355-v1', {
+-	manifest_aliases = {
+-		'tp-link-re355', -- upgrade from OpenWrt 19.07
+-	},
+-	packages = ATH10K_PACKAGES_QCA9880,
+-	broken = true, -- OOM with 5GHz enabled in most environments if device is 64M RAM variant
+-	class = 'tiny', -- Only 6M of usable Firmware space
+-})
+-
+-device('tp-link-re450-v1', 'tplink_re450-v1', {
+-	packages = ATH10K_PACKAGES_QCA9880,
+-	manifest_aliases = {
+-		'tp-link-re450', -- upgrade from OpenWrt 19.07
+-	},
+-	class = 'tiny', -- Only 6M of usable Firmware space
+-})
+-
+ device('tp-link-tl-wdr3500-v1', 'tplink_tl-wdr3500-v1')
+ device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
+ device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
+-- 
+2.25.1
+


### PR DESCRIPTION
The flash size is not sufficient to host the minimal set of FFMuc packages