### PR TITLE
site: add ffac-ssid-changer

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -154,5 +154,14 @@
       },
     },
   },
+
+  ssid_changer = {
+    enabled = true,
+    switch_timeframe = 15,    -- only once every timeframe (in minutes) the SSID will change to the Offline-SSID
+    first = 5,                -- the first few minutes directly after reboot within which an Offline-SSID may be activated every minute
+    prefix = 'offline.ffmuc.net/', -- use something short to leave space for the nodename (no '~' allowed!)
+    suffix = 'nodename',      -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
+    tq_limit_enabled = false, -- incompatible with Batman V. The offline SSID will only be set if there is no gateway reacheable.
+  },
 }
 -- vim: set ft=lua:ts=2:sw=2:et

--- a/site.mk
+++ b/site.mk
@@ -17,6 +17,7 @@ GLUON_FEATURES := \
 	web-wizard
 
 GLUON_SITE_PACKAGES := \
+	ffac-ssid-changer \
 	ffho-ap-timer \
 	ffho-autoupdater-wifi-fallback \
 	ffho-web-ap-timer \


### PR DESCRIPTION
This new feature will turn the SSID from this node (random example): https://map.ffmuc.net/#!/en/map/50d4f75974f1
from `muenchen.freifunk.net/augsburg` to `offline.ffmuc.net/ffmuc-50d4f75974f1`.

While the current code will apply to other domains, like `wertingen.freifunk.net/event` to `offline.ffmuc.net/whatevernodename`, we *can* make the options domain-specific and respect wertingen (and ffdon).

~~Alternatively, we can change it to `offline.freifunk.net/ffmuc-50d4f75974f1`, but the domain http://offline.freifunk.net is currently unused. Do we care?~~

EDIT: edited domains to reflext new changes

Fixes #249.