### PR TITLE
[Backport stable] site: use new generic ffac-change-autoupdater

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -163,5 +163,10 @@
     suffix = 'nodename',      -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
     tq_limit_enabled = false, -- incompatible with Batman V. The offline SSID will only be set if there is no gateway reacheable.
   },
+
+  update_channel = {
+    from_name = 'next', -- false to catch all
+    to_name = 'stable', -- if to_name is defined, autoupdater branch is set to it on upgrade
+  },
 }
 -- vim: set ft=lua:ts=2:sw=2:et

--- a/site.mk
+++ b/site.mk
@@ -18,10 +18,10 @@ GLUON_FEATURES := \
 
 GLUON_SITE_PACKAGES := \
 	ffac-autoupdater-wifi-fallback \
+	ffac-change-autoupdater \
 	ffac-ssid-changer \
 	ffho-ap-timer \
 	ffho-web-ap-timer \
-	ffmuc-autoupdater-next2stable \
 	ffmuc-mesh-vpn-wireguard-vxlan \
 	ffmuc-simple-radv-filter \
 	iwinfo \


### PR DESCRIPTION
# Description
Similar means to #274, we replace `ffmuc-autoupdater-next2stable` with `ffac-change-autoupdater`.