### PR TITLE
site: replace ffmuc-eol-ssid with new ffac-eol-ssid

### DIFF
--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -171,7 +171,7 @@ PKGS_TLS = PackageList('TLS', [
 pkglists.append(PKGS_TLS)
 
 PKGS_EOL = PackageList('EOL', [
-    'ffmuc-eol-ssid'
+    'ffac-eol-ssid'
 ])
 pkglists.append(PKGS_EOL)
 

--- a/modules
+++ b/modules
@@ -6,7 +6,7 @@
 ##	GLUON_SITE_FEEDS
 #		for each feed name given, add the corresponding PACKAGES_* lines
 #		documented below
-GLUON_SITE_FEEDS='ssidchanger ffmuc wireguard'
+GLUON_SITE_FEEDS='eolssid ssidchanger ffmuc wireguard'
 
 ##	PACKAGES_FFMUC_REPO
 #		the  git repository from where to clone the package feed
@@ -28,3 +28,6 @@ PACKAGES_WIREGUARD_COMMIT=876a8d8f9805281e95815b7d2d5a4d997a393dc6
 
 PACKAGES_SSIDCHANGER_REPO=https://github.com/Freifunk-Nord/gluon-ssid-changer.git
 PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5
+
+PACKAGES_EOLSSID_REPO=https://github.com/freifunk-gluon/community-packages/
+PACKAGES_EOLSSID_COMMIT=ad140c715793ec92110899b3b08ec5f2bf93a7be

--- a/site.conf
+++ b/site.conf
@@ -141,5 +141,10 @@
     suffix = 'nodename',      -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
     tq_limit_enabled = false, -- incompatible with Batman V. The offline SSID will only be set if there is no gateway reacheable.
   },
+
+  eol_ssid = {
+    enabled = true,
+    ssid = 'bitte-router-erneuern.ffmuc.net',
+  }
 }
 -- vim: set ft=lua:ts=2:sw=2:et

--- a/site.mk
+++ b/site.mk
@@ -194,10 +194,10 @@ EXCLUDE_TLS := \
 	-libustream-openssl
 
 INCLUDE_EOL := \
-    ffmuc-eol-ssid
+	ffac-eol-ssid
 
 EXCLUDE_EOL := \
-    -ffmuc-eol-ssid
+	-ffac-eol-ssid
 
 ifeq ($(GLUON_TARGET),ar71xx-generic)
 	GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
@@ -264,7 +264,7 @@ ifeq ($(GLUON_TARGET),ar71xx-nand)
 endif
 
 ifeq ($(GLUON_TARGET),ar71xx-tiny)
-    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
+	GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
 endif
 
@@ -356,7 +356,7 @@ ifeq ($(GLUON_TARGET),ramips-mt76x8)
 endif
 
 ifeq ($(GLUON_TARGET),ramips-rt305x)
-    GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
+	GLUON_SITE_PACKAGES += $(INCLUDE_EOL)
 
 endif
 


### PR DESCRIPTION
This new package allows toggling the eol-ssid per domain/site