### PR TITLE
temporarily remove FritzBox 7530/7520, but enable ipq40xx-generic

### DIFF
--- a/patches/temporarily-remove-FritzBox-7530-7520.patch
+++ b/patches/temporarily-remove-FritzBox-7530-7520.patch
@@ -1,0 +1,30 @@
+From f5cdf007b2873beaa2f5c6ce80f732c793f07f33 Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Sun, 5 Nov 2023 17:08:30 +0100
+Subject: [PATCH] targets: temporarily remove FritzBox 7530/7520
+
+Updating to Gluon 2023.1.1 bricks these devices
+https://github.com/freifunk-gluon/gluon/issues/3023
+---
+ targets/ipq40xx-generic | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/targets/ipq40xx-generic b/targets/ipq40xx-generic
+index df81a1b0..30c37ab5 100644
+--- a/targets/ipq40xx-generic
++++ b/targets/ipq40xx-generic
+@@ -56,11 +56,6 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
+ 	},
+ })
+ 
+-device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
+-	factory = false,
+-	aliases = {'avm-fritz-box-7520'},
+-})
+-
+ device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
+ 	factory = false,
+ })
+-- 
+2.34.1
+

--- a/targets
+++ b/targets
@@ -5,6 +5,7 @@ bcm27xx-bcm2708
 bcm27xx-bcm2709
 bcm27xx-bcm2710
 bcm27xx-bcm2711
+ipq40xx-generic
 ipq40xx-mikrotik
 ipq806x-generic
 lantiq-xrx200


### PR DESCRIPTION
Updating to Gluon 2023.1.1 bricks the FritzBox 7530 and 7520. There are currently no known workarounds, but it seems that other ipq40xx-generic devices are not affected.

For details, see:
https://github.com/freifunk-gluon/gluon/issues/3023