### PR TITLE
site: install ffac-eol-ssid on all devices

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -32,6 +32,7 @@ GLUON_MULTIDOMAIN=1
 #		chosen feature flags
 
 GLUON_SITE_PACKAGES := \
+	ffac-eol-ssid \
 	ffho-ap-timer \
 	ffho-autoupdater-wifi-fallback \
 	ffho-web-ap-timer \


### PR DESCRIPTION
As this branch only builds for legacy devices, it is safe to assume that all devices installing firmware here need updating.