### PR TITLE
site: use new ffmuc-ipv6-ra-filter

### DIFF
--- a/modules
+++ b/modules
@@ -26,7 +26,7 @@ PACKAGES_WIREGUARD_REPO=https://github.com/freifunk-gluon/community-packages.git
 
 ##	PACKAGES_WIREGUARD_COMMIT
 #		the version/commit of the git repository to clone
-PACKAGES_WIREGUARD_COMMIT=ca08c5446221cee0fc3d65b7dff2f12101a3ca59
+PACKAGES_WIREGUARD_COMMIT=394a373c78533c3b492d3f8ee55d1f7f74cf7cf1
 
 ##  PACKAGES_WIREGUARD_BRANCH
 #   the branch to check out

--- a/site.mk
+++ b/site.mk
@@ -22,8 +22,8 @@ GLUON_SITE_PACKAGES := \
 	ffac-ssid-changer \
 	ffho-ap-timer \
 	ffho-web-ap-timer \
+	ffmuc-ipv6-ra-filter \
 	ffmuc-mesh-vpn-wireguard-vxlan \
-	ffmuc-simple-radv-filter \
 	iwinfo \
 	respondd-module-airtime
 


### PR DESCRIPTION

   Replaces the ffmuc-simple-radvd filter with the new upstreamed version.
    The new version has some improvements, including improved handling of
    RA filtering when there is no active gateway available yet.