### PR TITLE
[Backport legacy] github: only create release if a tag was pushed

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -64,7 +64,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     needs: build_firmware
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
# Description
Backport of #292 to `legacy`.