### PR TITLE
domains: disable eol-ssid for ffdon

### DIFF
--- a/domains/ffdon_mitte.conf
+++ b/domains/ffdon_mitte.conf
@@ -79,4 +79,10 @@
       },
     },
   },
+
+  eol_ssid = {
+    -- disable eol_ssid to allow a smooth migration from Gluon v2020.1 (latest
+    -- ffdon firmware) to Gluon v2021 (latest ffmuc legacy firmware)
+    enabled = false,
+  }
 }

--- a/domains/ffdon_nordwest.conf
+++ b/domains/ffdon_nordwest.conf
@@ -78,4 +78,10 @@
       },
     },
   },
+
+  eol_ssid = {
+    -- disable eol_ssid to allow a smooth migration from Gluon v2020.1 (latest
+    -- ffdon firmware) to Gluon v2021 (latest ffmuc legacy firmware)
+    enabled = false,
+  }
 }

--- a/domains/ffdon_sued.conf
+++ b/domains/ffdon_sued.conf
@@ -80,4 +80,10 @@
       },
     },
   },
+
+  eol_ssid = {
+    -- disable eol_ssid to allow a smooth migration from Gluon v2020.1 (latest
+    -- ffdon firmware) to Gluon v2021 (latest ffmuc legacy firmware)
+    enabled = false,
+  }
 }


### PR DESCRIPTION
We need to migrate all devices from Gluon v2020.1 (ffdons latest firmware) to Gluon v2021.x which coincidentally is ffmucs legacy firmware.