### PR TITLE
domains: remove legacy ffdon domains

### DIFF
--- a/domains/ffdon_mitte.conf
+++ b/domains/ffdon_mitte.conf
@@ -1,11 +1,8 @@
 {
   domain_names = {
     ffdon_mitte = 'Freifunk Donau-Ries - Mitte',
-    ffdon_wemding = 'Freifunk Donau-Ries Wemding',
-    ffdon_monheim = 'Freifunk Donau-Ries Monheim',
-    ffdon_harburg = 'Freifunk Donau-Ries Harburg',
   },
-  hide_domain = { 'ffdon_wemding', 'ffdon_monheim', 'ffdon_harburg' }, -- legacy domains, only used for migration
+
   domain_seed = 'b9d58035a5a2256627a813ee9d10ebdbf53bbac562fddf240c28ed2becf4c0ec',
 
   prefix4 = '10.86.128.0/21',

--- a/domains/ffdon_nordwest.conf
+++ b/domains/ffdon_nordwest.conf
@@ -1,10 +1,8 @@
 {
   domain_names = {
     ffdon_nordwest = 'Freifunk Donau-Ries - Nordwest',
-    ffdon_noerdlingen = 'Freifunk Donau-Ries Noerdlingen',
-    ffdon_oettingen = 'Freifunk Donau-Ries Oettingen',
   },
-  hide_domain = { 'ffdon_noerdlingen', 'ffdon_oettingen' }, -- legacy domains, only used for migration
+
   domain_seed = '0cd943171cdc3afa3546a01dbbb48a6386fc871251f4e55f785e23bdbe3b31c4',
 
   prefix4 = '10.86.136.0/21',

--- a/domains/ffdon_sued.conf
+++ b/domains/ffdon_sued.conf
@@ -1,12 +1,8 @@
 {
   domain_names = {
     ffdon_sued = 'Freifunk Donau-Ries - Süd',
-    ffdon_donauwoerth = 'Freifunk Donau-Ries Donauwoerth',
-    ffdon_baeumenheim = 'Freifunk Donau-Ries Baeumenheim',
-    ffdon_rain = 'Freifunk Donau-Ries Rain',
-    ffdon_umland = 'Freifunk Donau-Ries Umland',
   },
-  hide_domain = { 'ffdon_donauwoerth', 'ffdon_baeumenheim', 'ffdon_rain', 'ffdon_umland' }, -- legacy domains, only used for migration
+
   domain_seed = '022be6c32c6ccd16744fbee39354451551c2a21b10b3331082e527d7a7705a7f',
 
   prefix4 = '10.86.144.0/21',


### PR DESCRIPTION
The legacy domains do not work with the wgkex broker and will make the device unreachable if selected.