### PR TITLE
[Backport legacy] github: downgrade upload-artifact to v3

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -55,7 +55,7 @@ jobs:
           make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} V=s
           echo "status=success" >> $GITHUB_OUTPUT
       - name: Upload firmware ${{ matrix.target }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         if: steps.compile.outputs.status == 'success'
         with:
           name: ${{ matrix.target }}_output


### PR DESCRIPTION
# Description
Backport of #336 to `legacy`.