### PR TITLE
contrib: remove USB and add NSM to ZyXEL NWA55AXE

### DIFF
--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -184,6 +184,11 @@ PKGS_TLS = PackageList('TLS', [
 ])
 pkglists.append(PKGS_TLS)
 
+PKGS_NSM = PackageList('NSM', [
+    'ffda-network-setup-mode',
+])
+pkglists.append(PKGS_NSM)
+
 #
 # package assignment
 #
@@ -255,10 +260,13 @@ targets.get('ramips-mt7621'). \
     add_pkglist(PKGS_USB_SERIAL). \
     add_pkglist(PKGS_USB_STORAGE). \
     add_pkglist(PKGS_TLS). \
+    include(['zyxel-nwa55axe'], pkglists=[PKGS_NSM]). \
     exclude([  # devices without usb ports
         'netgear-ex6150',
         'ubiquiti-edgerouter-x',
-        'ubiquiti-edgerouter-x-sfp'], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
+        'ubiquiti-edgerouter-x-sfp',
+        'zyxel-nwa55axe',
+    ], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
 
 targets.get('ramips-mt7620'). \
 	add_pkglist(PKGS_USB). \

--- a/site.mk
+++ b/site.mk
@@ -159,6 +159,12 @@ EXCLUDE_TLS := \
     -ca-bundle \
     -libustream-openssl
 
+INCLUDE_NSM := \
+    ffda-network-setup-mode
+
+EXCLUDE_NSM := \
+    -ffda-network-setup-mode
+
 ifeq ($(GLUON_TARGET),ath79-generic)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS)
 
@@ -262,9 +268,11 @@ endif
 ifeq ($(GLUON_TARGET),ramips-mt7621)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
 
+    GLUON_zyxel-nwa55axe_SITE_PACKAGES += $(INCLUDE_NSM)
     GLUON_netgear-ex6150_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
     GLUON_ubiquiti-edgerouter-x_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
     GLUON_ubiquiti-edgerouter-x-sfp_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
+    GLUON_zyxel-nwa55axe_SITE_PACKAGES += $(EXCLUDE_USB) $(EXCLUDE_USB_NET) $(EXCLUDE_USB_SERIAL) $(EXCLUDE_USB_STORAGE)
 endif
 
 ifeq ($(GLUON_TARGET),ramips-mt76x8)


### PR DESCRIPTION
The Zyxel has no reset button and requires a special NSM package for resetting the router using a magic networking package.