### PR TITLE
[Backport next] contrib: add USB and TLS to ipq40xx-mikrotik and ath79-mikrotik

### DIFF
--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -196,7 +196,7 @@ pkglists.append(PKGS_NSM)
 # package assignment
 #
 
-targets.get('ath79-generic'). \
+targets['ath79-generic']. \
     add_pkglist(PKGS_TLS). \
     include([ # 7M usable firmware space + USB port
         'devolo-wifi-pro-1750e',
@@ -219,14 +219,14 @@ targets.get('ath79-generic'). \
     ], pkglists=[PKGS_TLS])
 
 for target in ['ath79-nand', 'ipq40xx-generic', 'ipq806x-generic', 'lantiq-xway', 'mpc85xx-p1010', 'mpc85xx-p1020', 'mvebu-cortexa9', 'rockchip-armv8', 'sunxi-cortexa7']:
-    targets.get(target). \
+    targets[target]. \
         add_pkglist(PKGS_USB). \
         add_pkglist(PKGS_USB_NET). \
         add_pkglist(PKGS_USB_SERIAL). \
         add_pkglist(PKGS_USB_STORAGE). \
         add_pkglist(PKGS_TLS)
 
-targets.get('lantiq-xrx200'). \
+targets['lantiq-xrx200']. \
         add_pkglist(PKGS_USB). \
         add_pkglist(PKGS_USB_NET). \
         add_pkglist(PKGS_USB_SERIAL). \
@@ -238,10 +238,10 @@ targets.get('lantiq-xrx200'). \
             'tp-link-td-w8980'
         ], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
 
-targets.get('mpc85xx-p1020').add_pkglist(PKGS_TLS)
+targets['mpc85xx-p1020'].add_pkglist(PKGS_TLS)
 
 for target in ['bcm27xx-bcm2708', 'bcm27xx-bcm2709', 'bcm27xx-bcm2710', 'bcm27xx-bcm2711']:
-    targets.get(target). \
+    targets[target]. \
         add_pkglist(PKGS_USB). \
         add_pkglist(PKGS_USB_NET). \
         add_pkglist(PKGS_USB_SERIAL). \
@@ -249,7 +249,7 @@ for target in ['bcm27xx-bcm2708', 'bcm27xx-bcm2709', 'bcm27xx-bcm2710', 'bcm27xx
         add_pkglist(PKGS_USB_HID). \
         add_pkglist(PKGS_TLS)
 
-targets.get('mediatek-mt7622'). \
+targets['mediatek-mt7622']. \
     add_pkglist(PKGS_USB). \
     add_pkglist(PKGS_USB_NET). \
     add_pkglist(PKGS_USB_SERIAL). \
@@ -258,7 +258,7 @@ targets.get('mediatek-mt7622'). \
     exclude([  # devices without usb ports
         'ubiquiti-unifi-6-lr-v1'], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
 
-targets.get('ramips-mt7621'). \
+targets['ramips-mt7621']. \
     add_pkglist(PKGS_USB). \
     add_pkglist(PKGS_USB_NET). \
     add_pkglist(PKGS_USB_SERIAL). \
@@ -272,16 +272,16 @@ targets.get('ramips-mt7621'). \
         'zyxel-nwa55axe',
     ], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
 
-targets.get('ramips-mt7620'). \
-	add_pkglist(PKGS_USB). \
-	add_pkglist(PKGS_USB_NET). \
-	add_pkglist(PKGS_USB_SERIAL). \
-	add_pkglist(PKGS_USB_STORAGE). \
-	add_pkglist(PKGS_TLS). \
-	exclude([  # devices without usb ports
-		'netgear-ex3700'], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
+targets['ramips-mt7620']. \
+    add_pkglist(PKGS_USB). \
+    add_pkglist(PKGS_USB_NET). \
+    add_pkglist(PKGS_USB_SERIAL). \
+    add_pkglist(PKGS_USB_STORAGE). \
+    add_pkglist(PKGS_TLS). \
+    exclude([  # devices without usb ports
+        'netgear-ex3700'], pkglists=[PKGS_USB, PKGS_USB_NET, PKGS_USB_SERIAL, PKGS_USB_STORAGE])
 
-targets.get('ramips-mt76x8'). \
+targets['ramips-mt76x8']. \
     add_pkglist(PKGS_TLS). \
     include([ # 7M usable firmware space + USB port
         'gl-mt300n-v2',

--- a/contrib/genpkglist.py
+++ b/contrib/genpkglist.py
@@ -218,7 +218,19 @@ targets['ath79-generic']. \
         'd-link-dir825b1',
     ], pkglists=[PKGS_TLS])
 
-for target in ['ath79-nand', 'ipq40xx-generic', 'ipq806x-generic', 'lantiq-xway', 'mpc85xx-p1010', 'mpc85xx-p1020', 'mvebu-cortexa9', 'rockchip-armv8', 'sunxi-cortexa7']:
+for target in [
+    "ath79-mikrotik",
+    "ath79-nand",
+    "ipq40xx-generic",
+    "ipq40xx-mikrotik",
+    "ipq806x-generic",
+    "lantiq-xway",
+    "mpc85xx-p1010",
+    "mpc85xx-p1020",
+    "mvebu-cortexa9",
+    "rockchip-armv8",
+    "sunxi-cortexa7",
+]:
     targets[target]. \
         add_pkglist(PKGS_USB). \
         add_pkglist(PKGS_USB_NET). \

--- a/site.mk
+++ b/site.mk
@@ -191,8 +191,10 @@ ifeq ($(GLUON_TARGET),ath79-generic)
     GLUON_d-link-dir825b1_SITE_PACKAGES += $(EXCLUDE_TLS)
 endif
 
-# no pkglists for target ath79-mikrotik
+ifeq ($(GLUON_TARGET),ath79-mikrotik)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
 
+endif
 
 ifeq ($(GLUON_TARGET),ath79-nand)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
@@ -224,8 +226,10 @@ ifeq ($(GLUON_TARGET),ipq40xx-generic)
 
 endif
 
-# no pkglists for target ipq40xx-mikrotik
+ifeq ($(GLUON_TARGET),ipq40xx-mikrotik)
+    GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)
 
+endif
 
 ifeq ($(GLUON_TARGET),ipq806x-generic)
     GLUON_SITE_PACKAGES += $(INCLUDE_TLS) $(INCLUDE_USB) $(INCLUDE_USB_NET) $(INCLUDE_USB_SERIAL) $(INCLUDE_USB_STORAGE)


### PR DESCRIPTION
# Description
Backport of #341 to `next`.
