### PR TITLE
[actions] update to latest action using node20 instead of deprecated node16

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,6 @@ jobs:
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@v2

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -22,7 +22,7 @@ jobs:
       build_target_json: ${{ steps.set_target.outputs.build_target }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set target matrix
         id: set_target
         shell: bash
@@ -44,7 +44,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install build dependencies
@@ -63,7 +63,7 @@ jobs:
           make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} V=s
           echo "status=success" >> $GITHUB_OUTPUT
       - name: Upload firmware ${{ matrix.target }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.compile.outputs.status == 'success'
         with:
           name: ${{ matrix.target }}_output
@@ -76,7 +76,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Display structure of artifacts
         run: ls -R
       - name: Create tar.gz files
@@ -86,7 +86,7 @@ jobs:
             tar zcvf "${output}.tar.gz" "${output}"
           done
       - name: Create Release & Upload Release Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           # Note: If there is no release name specified, releases created in
           # the GitHub UI do not trigger a failure and are modified instead.

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: shellcheck
         # Make sure the action is pinned to a commit, as all reviewdog repos
         # have hundreds of contributors with write access (breaks easy/often)


### PR DESCRIPTION
Currently each pipeline has warnings to it regarding the deprecation of node.js 16 actions like:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This PR updates the versions of the pipeline accordingly.
See also:

https://github.com/actions/checkout/releases
https://github.com/korthout/backport-action/releases
https://github.com/softprops/action-gh-release/releases