### PR TITLE
[Backport legacy] modules: use latest packages for ffmuc-mesh-vpn-wireguard and ffmuc-ipv6-ra-filter

### DIFF
--- a/domains/ffdon_mitte.conf
+++ b/domains/ffdon_mitte.conf
@@ -48,10 +48,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffdon_nordwest.conf
+++ b/domains/ffdon_nordwest.conf
@@ -48,10 +48,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffdon_sued.conf
+++ b/domains/ffdon_sued.conf
@@ -48,10 +48,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_augsburg.conf
+++ b/domains/ffmuc_augsburg.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_freising.conf
+++ b/domains/ffmuc_freising.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_gauting.conf
+++ b/domains/ffmuc_gauting.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_muc_cty.conf
+++ b/domains/ffmuc_muc_cty.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_muc_nord.conf
+++ b/domains/ffmuc_muc_nord.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_muc_ost.conf
+++ b/domains/ffmuc_muc_ost.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_muc_sued.conf
+++ b/domains/ffmuc_muc_sued.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_muc_west.conf
+++ b/domains/ffmuc_muc_west.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_uml_nord.conf
+++ b/domains/ffmuc_uml_nord.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_uml_ost.conf
+++ b/domains/ffmuc_uml_ost.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_uml_sued.conf
+++ b/domains/ffmuc_uml_sued.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_uml_west.conf
+++ b/domains/ffmuc_uml_west.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffmuc_welt.conf
+++ b/domains/ffmuc_welt.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffwert_city.conf
+++ b/domains/ffwert_city.conf
@@ -47,10 +47,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/domains/ffwert_events.conf
+++ b/domains/ffwert_events.conf
@@ -48,10 +48,11 @@
   mesh_vpn = {
     mtu = 1406,
     wireguard = {
-      enabled = 'true',
+      enabled = true,
       iface = 'wg_mesh_vpn',
-      limit = '1', -- actually unused
-      broker = 'broker.ffmuc.net/api/v1/wg/key/exchange',
+      mtu = 1406,
+      broker = 'broker.ffmuc.net',
+      loadbalancing = 'on-by-default',
       peers = {
         {
           publickey ='TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=',

--- a/modules
+++ b/modules
@@ -6,7 +6,7 @@
 ##	GLUON_SITE_FEEDS
 #		for each feed name given, add the corresponding PACKAGES_* lines
 #		documented below
-GLUON_SITE_FEEDS='community ssidchanger ffmuc wireguard'
+GLUON_SITE_FEEDS='community ssidchanger ffmuc'
 
 ##	PACKAGES_FFMUC_REPO
 #		the  git repository from where to clone the package feed
@@ -20,12 +20,6 @@ PACKAGES_FFMUC_COMMIT=c1c668905b5dc9cc69acb663569a1905f003ffb7
 #   the branch to check out
 PACKAGES_FFMUC_BRANCH=main
 
-##	PACKAGES_WIREGUARD_REPO
-#		the  git repository from where to clone the package feed
-PACKAGES_WIREGUARD_REPO=https://github.com/freifunkMUC/community-packages.git
-PACKAGES_WIREGUARD_BRANCH=legacy
-PACKAGES_WIREGUARD_COMMIT=876a8d8f9805281e95815b7d2d5a4d997a393dc6
-
 PACKAGES_SSIDCHANGER_REPO=https://github.com/Freifunk-Nord/gluon-ssid-changer.git
 PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5
 
@@ -33,5 +27,8 @@ PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5
 # ff-ap-timer
 # ff-web-ap-timer
 # ffac-eol-ssid
-PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages/
-PACKAGES_COMMUNITY_COMMIT=0f9f758e0927dcd344800dbc9084465e91670b6f
+# ffmuc-mesh-vpn-wireguard-vxlan
+# ffmuc-ipv6-ra-filter
+PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
+PACKAGES_COMMUNITY_COMMIT=1e70e0744846de83f0b42384bd326a1cde5d9a1a
+PACKAGES_COMMUNITY_BRANCH=master

--- a/modules
+++ b/modules
@@ -30,5 +30,5 @@ PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5
 # ffmuc-mesh-vpn-wireguard-vxlan
 # ffmuc-ipv6-ra-filter
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=1e70e0744846de83f0b42384bd326a1cde5d9a1a
+PACKAGES_COMMUNITY_COMMIT=0c4b507dc9024a52ea320bfc6ba769a0ecbe4a46
 PACKAGES_COMMUNITY_BRANCH=master

--- a/patches/0001-gluon-core-add-gluon-info-binary.patch
+++ b/patches/0001-gluon-core-add-gluon-info-binary.patch
@@ -1,0 +1,64 @@
+From 42811401a12568bab07be160c674a229e0572367 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Wed, 12 Jan 2022 01:31:58 +0100
+Subject: [PATCH 1/4] gluon-core: add gluon info binary
+
+This copies the code from web-admin and uses it to create a neat
+cli-accessible summary about a node
+
+This could also be extended or possibly have all the data the status
+page has
+
+Co-Authored-By: Matthias Schiffer <mschiffer@universe-factory.net>
+---
+ package/gluon-core/luasrc/usr/bin/gluon-info | 38 ++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+ create mode 100755 package/gluon-core/luasrc/usr/bin/gluon-info
+
+diff --git a/package/gluon-core/luasrc/usr/bin/gluon-info b/package/gluon-core/luasrc/usr/bin/gluon-info
+new file mode 100755
+index 00000000..8cee2895
+--- /dev/null
++++ b/package/gluon-core/luasrc/usr/bin/gluon-info
+@@ -0,0 +1,38 @@
++#!/usr/bin/lua
++
++local uci = require('simple-uci').cursor()
++local pretty_hostname = require 'pretty_hostname'
++
++local site = require 'gluon.site'
++local sysconfig = require 'gluon.sysconfig'
++local platform = require 'gluon.platform'
++local util = require 'gluon.util'
++local has_vpn, vpn = pcall(require, 'gluon.mesh-vpn')
++
++local pubkey
++if has_vpn and vpn.enabled() then
++	local _, active_vpn = vpn.get_active_provider()
++
++	if active_vpn ~= nil then
++		pubkey = active_vpn.public_key()
++	end
++end
++
++local values = {
++	{ 'Hostname', pretty_hostname.get(uci) },
++	{ 'MAC address', sysconfig.primary_mac },
++	{ 'Hardware model', platform.get_model() },
++	{ 'Gluon version' .. " / " .. 'Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
++		.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
++	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
++	{ 'Site', site.site_name() },
++	{ 'Public VPN key', pubkey or 'n/a' },
++}
++
++local padTo = 24
++
++for _, info in ipairs(values) do
++	local labelLen = string.len(info[1]) + 1
++
++	print(info[1] .. ':' .. string.rep(' ', padTo - labelLen), info[2])
++end
+-- 
+2.34.1
+

--- a/patches/0002-gluon-mesh-vpn-wireguard-fix-empty-string-key.patch
+++ b/patches/0002-gluon-mesh-vpn-wireguard-fix-empty-string-key.patch
@@ -1,0 +1,28 @@
+From 95e711a4a8bba9ef5b9103f8eefda18329fa97a9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Wed, 12 Jan 2022 01:36:03 +0100
+Subject: [PATCH 2/4] gluon-mesh-vpn-wireguard: fix empty string key
+
+Co-Authored-By: Matthias Schiffer <mschiffer@universe-factory.net>
+---
+ package/gluon-core/luasrc/usr/bin/gluon-info | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/gluon-core/luasrc/usr/bin/gluon-info b/package/gluon-core/luasrc/usr/bin/gluon-info
+index 8cee2895..c25018d1 100755
+--- a/package/gluon-core/luasrc/usr/bin/gluon-info
++++ b/package/gluon-core/luasrc/usr/bin/gluon-info
+@@ -22,8 +22,8 @@ local values = {
+ 	{ 'Hostname', pretty_hostname.get(uci) },
+ 	{ 'MAC address', sysconfig.primary_mac },
+ 	{ 'Hardware model', platform.get_model() },
+-	{ 'Gluon version' .. " / " .. 'Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
+-		.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
++	{ 'Gluon version / Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
++		.. ' / ' .. util.trim(util.readfile('/lib/gluon/site-version')) },
+ 	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
+ 	{ 'Site', site.site_name() },
+ 	{ 'Public VPN key', pubkey or 'n/a' },
+-- 
+2.34.1
+

--- a/patches/0003-gluon-info-Add-current-domain-to-gluon-info.patch
+++ b/patches/0003-gluon-info-Add-current-domain-to-gluon-info.patch
@@ -1,0 +1,26 @@
+From a95ce4c9aafc2476fedc1310bb9fd021a6368683 Mon Sep 17 00:00:00 2001
+From: Florian Maurer <f.maurer@outlook.de>
+Date: Wed, 10 May 2023 02:33:08 +0200
+Subject: [PATCH 3/4] gluon-info: Add current domain to gluon-info
+
+- provides easier information of the currently active domain
+- tested by patching a running node
+---
+ package/gluon-core/luasrc/usr/bin/gluon-info | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package/gluon-core/luasrc/usr/bin/gluon-info b/package/gluon-core/luasrc/usr/bin/gluon-info
+index c25018d1..74ffe59d 100755
+--- a/package/gluon-core/luasrc/usr/bin/gluon-info
++++ b/package/gluon-core/luasrc/usr/bin/gluon-info
+@@ -26,6 +26,7 @@ local values = {
+ 		.. ' / ' .. util.trim(util.readfile('/lib/gluon/site-version')) },
+ 	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
+ 	{ 'Site', site.site_name() },
++	{ 'Domain', uci:get('gluon', 'core', 'domain') or 'n/a' },
+ 	{ 'Public VPN key', pubkey or 'n/a' },
+ }
+ 
+-- 
+2.34.1
+

--- a/patches/0004-gluon-core-move-all-info-into-module.patch
+++ b/patches/0004-gluon-core-move-all-info-into-module.patch
@@ -1,0 +1,119 @@
+From d3fa7806d6c7499b20ad50d5fbb56dcb07f08b78 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Sat, 10 Jun 2023 15:26:44 +0200
+Subject: [PATCH 4/4] gluon-core: move all info into module
+
+---
+ package/gluon-core/luasrc/usr/bin/gluon-info  | 36 ++-----------
+ .../luasrc/usr/lib/lua/gluon/info.lua         | 50 +++++++++++++++++++
+ 2 files changed, 55 insertions(+), 31 deletions(-)
+ create mode 100644 package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua
+
+diff --git a/package/gluon-core/luasrc/usr/bin/gluon-info b/package/gluon-core/luasrc/usr/bin/gluon-info
+index 74ffe59d..916c0643 100755
+--- a/package/gluon-core/luasrc/usr/bin/gluon-info
++++ b/package/gluon-core/luasrc/usr/bin/gluon-info
+@@ -1,39 +1,13 @@
+ #!/usr/bin/lua
+ 
+-local uci = require('simple-uci').cursor()
+-local pretty_hostname = require 'pretty_hostname'
++local info = require 'gluon.info'
+ 
+-local site = require 'gluon.site'
+-local sysconfig = require 'gluon.sysconfig'
+-local platform = require 'gluon.platform'
+-local util = require 'gluon.util'
+-local has_vpn, vpn = pcall(require, 'gluon.mesh-vpn')
+-
+-local pubkey
+-if has_vpn and vpn.enabled() then
+-	local _, active_vpn = vpn.get_active_provider()
+-
+-	if active_vpn ~= nil then
+-		pubkey = active_vpn.public_key()
+-	end
+-end
+-
+-local values = {
+-	{ 'Hostname', pretty_hostname.get(uci) },
+-	{ 'MAC address', sysconfig.primary_mac },
+-	{ 'Hardware model', platform.get_model() },
+-	{ 'Gluon version / Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
+-		.. ' / ' .. util.trim(util.readfile('/lib/gluon/site-version')) },
+-	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
+-	{ 'Site', site.site_name() },
+-	{ 'Domain', uci:get('gluon', 'core', 'domain') or 'n/a' },
+-	{ 'Public VPN key', pubkey or 'n/a' },
+-}
++local values = info.get_info_pretty(function(str) return str end)
+ 
+ local padTo = 24
+ 
+-for _, info in ipairs(values) do
+-	local labelLen = string.len(info[1]) + 1
++for _, value in ipairs(values) do
++	local labelLen = string.len(value[1]) + 1
+ 
+-	print(info[1] .. ':' .. string.rep(' ', padTo - labelLen), info[2])
++	print(value[1] .. ':' .. string.rep(' ', padTo - labelLen), value[2])
+ end
+diff --git a/package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua b/package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua
+new file mode 100644
+index 00000000..7e6f5f39
+--- /dev/null
++++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua
+@@ -0,0 +1,50 @@
++local uci = require('simple-uci').cursor()
++local pretty_hostname = require 'pretty_hostname'
++
++local site = require 'gluon.site'
++local sysconfig = require 'gluon.sysconfig'
++local platform = require 'gluon.platform'
++local util = require 'gluon.util'
++local has_vpn, vpn = pcall(require, 'gluon.mesh-vpn')
++
++local pubkey
++if has_vpn and vpn.enabled() then
++	local _, active_vpn = vpn.get_active_provider()
++
++	if active_vpn ~= nil then
++		pubkey = active_vpn.public_key()
++	end
++end
++
++local M = {}
++
++function M.get_info()
++	return {
++		hostname = pretty_hostname.get(uci),
++		mac_address = sysconfig.primary_mac,
++		hardware_model = platform.get_model(),
++		gluon_version = util.trim(util.readfile('/lib/gluon/gluon-version')),
++		site_version = util.trim(util.readfile('/lib/gluon/site-version')),
++		firmware_release = util.trim(util.readfile('/lib/gluon/release')),
++		site = site.site_name(),
++		domain = uci:get('gluon', 'core', 'domain'),
++		public_vpn_key = pubkey,
++	}
++end
++
++function M.get_info_pretty(_)
++	local data = M.get_info()
++
++	return {
++		{ _('Hostname'), data.hostname },
++		{ _('MAC address'), data.mac_address },
++		{ _('Hardware model'), data.hardware_model },
++		{ _('Gluon version') .. " / " .. _('Site version'), data.gluon_version .. " / " .. data.site_version },
++		{ _('Firmware release'), data.firmware_release },
++		{ _('Site'), data.site },
++		{ _('Domain'), data.domain or 'n/a' },
++		{ _('Public VPN key'), data.public_vpn_key or 'n/a' },
++	}
++end
++
++return M
+-- 
+2.34.1
+

--- a/site.mk
+++ b/site.mk
@@ -37,8 +37,8 @@ GLUON_SITE_PACKAGES := \
 	ffac-eol-ssid \
 	ffdon-domain-merge \
 	ffho-autoupdater-wifi-fallback \
+	ffmuc-ipv6-ra-filter \
 	ffmuc-mesh-vpn-wireguard-vxlan \
-	ffmuc-simple-radv-filter \
 	gluon-ssid-changer \
 	iptables \
 	iwinfo \


### PR DESCRIPTION
This includes changes for wgkex loadbalancing as well as the new user-agent. Depends on the ffwert domains being merged.

Currently blocked by https://github.com/freifunk-gluon/community-packages/pull/109