### PR TITLE
[legacy] site: add basic ffulm-migration package

### DIFF
--- a/modules
+++ b/modules
@@ -11,13 +11,7 @@ GLUON_SITE_FEEDS='community ssidchanger ffmuc'
 ##	PACKAGES_FFMUC_REPO
 #		the  git repository from where to clone the package feed
 PACKAGES_FFMUC_REPO=https://github.com/freifunkMUC/gluon-packages.git
-
-##	PACKAGES_FFMUC_COMMIT
-#		the version/commit of the git repository to clone
-PACKAGES_FFMUC_COMMIT=c1c668905b5dc9cc69acb663569a1905f003ffb7
-
-##  PACKAGES_FFMUC_BRANCH
-#   the branch to check out
+PACKAGES_FFMUC_COMMIT=19f70a156bd921a352e9fd786f6d179618b18c07
 PACKAGES_FFMUC_BRANCH=main
 
 PACKAGES_SSIDCHANGER_REPO=https://github.com/Freifunk-Nord/gluon-ssid-changer.git

--- a/site.mk
+++ b/site.mk
@@ -39,6 +39,7 @@ GLUON_SITE_PACKAGES := \
 	ffho-autoupdater-wifi-fallback \
 	ffmuc-ipv6-ra-filter \
 	ffmuc-mesh-vpn-wireguard-vxlan \
+	ffulm-migration \
 	gluon-ssid-changer \
 	iptables \
 	iwinfo \

--- a/site.mk
+++ b/site.mk
@@ -71,7 +71,7 @@ GLUON_PRIORITY ?= 0
 GLUON_REGION ?= eu
 
 # Languages to include
-GLUON_LANGS ?= en de
+GLUON_LANGS ?= en
 
 # Do not build factory images for deprecated devices
 GLUON_DEPRECATED ?= upgrade


### PR DESCRIPTION
This packages allows migrating an ffulm firmware v2.1.5 to a gluon-based
v2021.1.x firmware. The fundamentals are inspired by setup-mode.
For details see here: [README.md](https://github.com/freifunkMUC/gluon-packages/blob/1e52fc5eacb3c1092e619b082426472057d79260/ffulm-migration/README.md)

Only the basics are migrated, for more details follow the more recent discussion here: https://github.com/freifunkMUC/site-ffm/pull/370#issuecomment-2041559383