### PR TITLE
Makefile: only change autoupdater branch and let autoupdater enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key
 
 GLUON_TARGETS ?= $(shell cat targets | tr '\n' ' ')
-GLUON_AUTOUPDATER_BRANCH := stable
+GLUON_AUTOUPDATER_ENABLED := 1
 
 ifneq (,$(shell git describe --exact-match --tags 2>/dev/null))
-	GLUON_AUTOUPDATER_ENABLED := 1
+	GLUON_AUTOUPDATER_BRANCH := stable
 	GLUON_RELEASE := $(shell git describe --tags 2>/dev/null)
 else
-	GLUON_AUTOUPDATER_ENABLED := 0
+	GLUON_AUTOUPDATER_BRANCH := experimental
 	EXP_FALLBACK = $(shell date '+%Y%m%d')
 	BUILD_NUMBER ?= $(EXP_FALLBACK)
 	GLUON_RELEASE := $(shell git describe --tags)~exp$(BUILD_NUMBER)


### PR DESCRIPTION
Makefile: only change autoupdater branch and let autoupdater enabled

this should avoid old test Versions
![image](https://github.com/freifunkMUC/site-ffm/assets/5702338/25c10cee-ff09-421b-ba1a-20ffbd5b45f7)

for the next backport we need to switch the branch to next instead of stable
