### PR TITLE
site: enable VPN by default

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -41,6 +41,7 @@
   },
 
   mesh_vpn = {
+    enabled = true,
     bandwidth_limit = {
       enabled = false,
       egress = 1500,


### PR DESCRIPTION
site: enable VPN by default

https://ffmuc.net/pad/p/treffen240327 - Punkt 3.5
`Bitte mesh_vpn by default im Config Modus aktivieren`
https://gluon.readthedocs.io/en/latest/user/site.html#configuration - mesh_vpn


![image](https://github.com/freifunkMUC/site-ffm/assets/5702338/598ac81a-8d8e-4728-a109-5485e04e9f47)

- [x] Test Upgrade if mesh vpn is then still disabled
