### PR TITLE
[Backport legacy] modules: ffmuc-mesh-vpn-wireguard: Cleanup Code

### DIFF
--- a/modules
+++ b/modules
@@ -24,5 +24,5 @@ PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5
 # ffmuc-mesh-vpn-wireguard-vxlan
 # ffmuc-ipv6-ra-filter
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
-PACKAGES_COMMUNITY_COMMIT=0c4b507dc9024a52ea320bfc6ba769a0ecbe4a46
+PACKAGES_COMMUNITY_COMMIT=8f0a9dc2a631c5e1a640fe1d8afc7470be34065a
 PACKAGES_COMMUNITY_BRANCH=master


### PR DESCRIPTION
# Description
Backport of #419 to `next`.


Confirmed tested.