### PR TITLE
gluon: add Patch cellular auth

### DIFF
--- a/patches/0001-gluon-web-cellular-add-auth-option-to-GUI.patch
+++ b/patches/0001-gluon-web-cellular-add-auth-option-to-GUI.patch
@@ -1,0 +1,108 @@
+From 3e1c937d0eb8946cc8226c7255734f6ffc26b3a5 Mon Sep 17 00:00:00 2001
+From: Tobias <5702338+T0biii@users.noreply.github.com>
+Date: Sat, 6 Jul 2024 01:03:28 +0200
+Subject: [PATCH] gluon-web-cellular: add auth option to GUI
+
+---
+ .../luasrc/lib/gluon/upgrade/250-cellular         |  2 ++
+ package/gluon-web-cellular/i18n/de.po             | 15 +++++++++++++++
+ .../i18n/gluon-web-cellular.pot                   | 15 +++++++++++++++
+ .../gluon/config-mode/model/admin/cellular.lua    |  9 +++++++++
+ 4 files changed, 41 insertions(+)
+
+diff --git a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+index 27294c4d..300347e3 100755
+--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
++++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+@@ -21,6 +21,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
+ 	local pincode = uci:get('gluon', 'cellular', 'pin')
+ 	local username = uci:get('gluon', 'cellular', 'username')
+ 	local password = uci:get('gluon', 'cellular', 'password')
++	local auth = uci:get('gluon', 'cellular', 'auth')
+ 
+ 	uci:section('network', 'interface', 'cellular', {
+ 		proto = control_type,
+@@ -40,6 +41,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
+ 	set_or_delete('network', 'cellular', 'pincode', pincode)
+ 	set_or_delete('network', 'cellular', 'username', username)
+ 	set_or_delete('network', 'cellular', 'password', password)
++	set_or_delete('network', 'cellular', 'auth', auth)
+ 	set_or_delete('network', 'cellular', 'delay', delay)
+ end
+ 
+diff --git a/package/gluon-web-cellular/i18n/de.po b/package/gluon-web-cellular/i18n/de.po
+index 81405234..daf464a4 100644
+--- a/package/gluon-web-cellular/i18n/de.po
++++ b/package/gluon-web-cellular/i18n/de.po
+@@ -47,3 +47,18 @@ msgstr ""
+ "Du kannst den Uplink über einen Mobilfunk Service aktivieren. Wenn du "
+ "dich dafür entscheidest, wird die VPN-Verbindung über das integrierte "
+ "Mobilfunk-Modem hergestellt."
++
++msgid "Authentication"
++msgstr "Authentifizierung"
++
++msgid "None"
++msgstr "Keine"
++
++msgid "PAP"
++msgstr ""
++
++msgid "CHAP"
++msgstr ""
++
++msgid "Both"
++msgstr "Beide"
+diff --git a/package/gluon-web-cellular/i18n/gluon-web-cellular.pot b/package/gluon-web-cellular/i18n/gluon-web-cellular.pot
+index 5b3b8ae0..cf345329 100644
+--- a/package/gluon-web-cellular/i18n/gluon-web-cellular.pot
++++ b/package/gluon-web-cellular/i18n/gluon-web-cellular.pot
+@@ -35,3 +35,18 @@ msgid ""
+ "You can enable uplink via cellular service. If you decide so, the VPN "
+ "connection is established using the integrated WWAN modem."
+ msgstr ""
++
++msgid "Authentication"
++msgstr ""
++
++msgid "None"
++msgstr ""
++
++msgid "PAP"
++msgstr ""
++
++msgid "CHAP"
++msgstr ""
++
++msgid "Both"
++msgstr ""
+diff --git a/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua b/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua
+index 38a4dd2c..123ed6f2 100644
+--- a/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua
++++ b/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua
+@@ -33,6 +33,14 @@ local password = s:option(Value, "password", translate("Password"))
+ password:depends(enabled, true)
+ password.default = uci:get('gluon', 'cellular', 'password')
+ 
++local auth = s:option(ListValue, "auth", translate("Authentication"))
++auth:depends(enabled, true)
++auth:value("none", translate("None"))
++auth:value("pap", translate("PAP"))
++auth:value("chap", translate("CHAP"))
++auth:value("both", translate("Both"))
++auth.default = uci:get('gluon', 'cellular', 'auth') or "none"
++
+ function f:write()
+ 	local cellular_enabled = false
+ 	if enabled.data then
+@@ -46,6 +54,7 @@ function f:write()
+ 		pin = pin.data,
+ 		username = username.data,
+ 		password = password.data,
++		auth = auth.data,
+ 	})
+ 
+ 	uci:commit('gluon')
+-- 
+2.45.1
+


### PR DESCRIPTION
gluon: add Patch cellular auth

`none, pap, chap, both`


as web-cellular only works atm on next i guess we dont need it on stable

Link to Gluon PR: https://github.com/freifunk-gluon/gluon/pull/3307