### PR TITLE
fix map link in custom banner

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -179,8 +179,8 @@
   },
 
   custom_banner = {
-    enabled     = true,                         -- optional (enabled by default)
-    map_url     = 'https://map.ffmuc.net/#!/',  -- optional (skipped by default)
-    contact_url = 'https://ffmuc.net/kontakt/', -- optional (skipped by default)
+    enabled     = true,                                -- optional (enabled by default)
+    map_url     = 'https://map.ffmuc.net/#!/de/map/',  -- optional (skipped by default)
+    contact_url = 'https://ffmuc.net/kontakt/',        -- optional (skipped by default)
   },
 }


### PR DESCRIPTION
Before, this produced URLs like `https://map.ffmuc.net/#!{NODEID}` which do not work