### PR TITLE
image: add ffda-wireless-rate-limiter

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -22,6 +22,7 @@ packages{
     'ffac-autoupdater-wifi-fallback',
     'ffac-change-autoupdater',
     'ffac-ssid-changer',
+    'ffda-wireless-rate-limiter',
     'ffmuc-ipv6-ra-filter',
     'ffmuc-mesh-vpn-wireguard-vxlan',
     'iwinfo',


### PR DESCRIPTION
https://github.com/freifunk-gluon/community-packages/blob/master/ffda-wireless-rate-limiter/README.md

we can set defaults in the site.conf if i understood correctly the defaults apply directly.
maybe we can add for this package a option in the webgui so the user can set also via gui