### PR TITLE
make: bump gluon 2024.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2023.2.3
+GLUON_GIT_REF := v2023.2.4
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
https://gluon.readthedocs.io/en/v2023.2.x/releases/v2023.2.4.html

Gluon 2023.2.4
==============

Added hardware support
----------------------

ramips-mt7620


- NETGEAR
  - EX6130


ramips-mt7621


- Xiaomi

  - Mi Router 4A (Gigabit Edition v2)


ramips-mt76x8


- TP-Link

  - RE200 (v4)


Bugfixes
--------

* Fixed an issue where Enterasys WS-AP3710i devices regularly boot with all-zero MAC-addresses in previous releases

* Detection of `swconfig` based switch architecture has been fixed 

* Fixed an issue where the AVM FRITZ!Box 4040 used an incorrect primary MAC address


Known issues
------------

* Unstable wireless with certain MediaTek devices 
* The integration of the BATMAN_V routing algorithm is incomplete.

  - Mesh neighbors don't appear on the status page.
    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
    metric.
  - Throughput values are not correctly acquired for different interface types.

    This affects virtual interface types like bridges and VXLAN.

* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown


  Reducing the TX power in the Advanced Settings is recommended.

* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled

  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).