### PR TITLE
site: remove *GLUON_RELEASE

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -29,11 +29,6 @@ GLUON_SITE_PACKAGES := \
 	iwinfo \
 	respondd-module-airtime
 
-DEFAULT_GLUON_RELEASE := v2022.10.1~exp$(shell date '+%Y%m%d%H')
-
-# Allow overriding the release number from the command line
-GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
-
 GLUON_PRIORITY ?= 0
 
 GLUON_REGION ?= eu


### PR DESCRIPTION
remove `*GLUON_RELEASE` from `site.mk` as it must set always be set. 
Our https://github.com/freifunkMUC/site-ffm/blob/42b99dc7e3dd26030bf659ec5092550ee2d61b60/Makefile set this value automatically via git