### PR TITLE
Use Github Bot for Actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,10 +4,7 @@ name: Backport merged pull request
 on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [closed, labeled]
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
-  actions: write # so it can create pull requests on actions/workflows
+
 jobs:
   backport:
     name: Backport pull request
@@ -15,10 +12,20 @@ jobs:
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Clone Firmware
+        uses: actions/checkout@v4 # v4
+      
+      - name: Get Github App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Create backport pull requests
         uses: korthout/backport-action@be567af183754f6a5d831ae90f648954763f17f5 # v3.1.0
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"

--- a/.github/workflows/bump-modules.yml
+++ b/.github/workflows/bump-modules.yml
@@ -4,23 +4,32 @@ name: "Update Modules base"
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
-
 jobs:
   update-Modules:
     runs-on: ubuntu-22.04
-    env:
-      COMMIT_NAME: github-actions[bot] 
-      COMMIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
     steps:
       - name: Clone Firmware
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@v4 # v4
+
+      - name: Get Github App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git User and E-Mail
         run: git config --global user.name "${{ env.COMMIT_NAME }}" && git config --global user.email "${{ env.COMMIT_EMAIL }}"
-        
+        env:
+          COMMIT_NAME:  ${{ steps.app-token.outputs.app-slug }}[bot] 
+          COMMIT_EMAIL: ${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
+
       - name: Get update branch name
         id: branch-name
         run: echo "branch-name=update-modules-${{ github.ref_name }}-$(date +%s)" >> $GITHUB_OUTPUT
@@ -32,6 +41,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@8867c4aba1b742c39f8d0ba35429c2dfa4b6cb20 # v7.0.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           title: '[${{ github.ref_name }}] update modules'
           body: |
             Update modules for ${{ github.ref_name }} branch

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,3 +1,4 @@
+---
 name: Build ffmuc firmware
 
 on:
@@ -28,7 +29,7 @@ jobs:
       build_target_json: ${{ steps.set_target.outputs.build_target }}
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@v4 # v4
       - name: Set target matrix
         id: set_target
         shell: bash
@@ -50,7 +51,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@v4 # v4
         with:
           fetch-depth: 0
       - name: Install build dependencies

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,7 +18,8 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Clone Firmware
+        uses: actions/checkout@v4 # v4
       - name: shellcheck
         # Make sure the action is pinned to a commit, as all reviewdog repos
         # have hundreds of contributors with write access (breaks easy/often)

--- a/.github/workflows/update-targets.yml
+++ b/.github/workflows/update-targets.yml
@@ -19,7 +19,21 @@ jobs:
   update-Modules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Clone Firmware
+        uses: actions/checkout@v4 # v4
+
+      - name: Get Github App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Get update branch name
         id: branch-name
@@ -36,14 +50,14 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@8867c4aba1b742c39f8d0ba35429c2dfa4b6cb20 # v7.0.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           title: '[${{ github.ref_name }}] Add targets ${{ steps.new-targets.outputs.names }}'
           body: |
             Updated targets for branch ${{ github.ref_name }}
 
             New targets: `${{ steps.new-targets.outputs.names }}`
-
-            ⚠️ Please trigger the CI before merging this pull request. ⚠️
           commit-message: "targets: add ${{ steps.new-targets.outputs.names }}"
+          committer: ${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
           branch: ${{ steps.branch-name.outputs.branch-name }}
           labels: ${{ github.ref_name }}
           draft: true # this step does not trigger a CI run, so always mark them as draft


### PR DESCRIPTION
Use Github Bot for Actions

ToDo

- [x] Add new Bot (GitHub Apps) in Org Context
	- [x] Set Name (This name is used for Commits and PR generation e.g. FFMUC Helper, FFMUC Bot)
	- [x] Set Homepage URL (e.g. https://ffmuc.net)
	- [x] Remove "Expire user authorization tokens"
	- [x] Remove "Webhook Active"
	- [x] Add Repository Permissions
		- [x] Actions Read and Write
		- [x] Contents Read and Write
		- [x] Issues Read and Write
		- [x] Metadata Read-only
		- [x] Pull requests Read and Write
		- [x] Workflows Read and Write
	- [x] Only on this account (@freifunkmuc)
- [x] After Creation of Bot
	- [x] General Tab
		- [x] save `App ID` for later
		- [x] save `Private keys` -> Generate a private key -> for later
	- [x] Install App Tab
		- [x] select @freifunkMUC Install
		- [x] Only select repositories (freifunkMUC/site-ffm)
- [x] Actions secrets and vars
	- [x] Add new Repository variables to Repo `APP_ID` -> previously saved
	- [x] Add new Repository secrets to Repo `PRIVATE_KEY` -> previously saved


die ToDos um den Bot zu erstellen kann ich übernehmen dafür fehlen mir die Github Rechte.
Die Var sowie das Secret könnten wir theoretisch auch als Org Secrets setzen, falls wir den Bot auf mehreren Repos brauchen.

Für folgende Workflows könnten wir es noch verwenden:
- [x] https://github.com/freifunkMUC/site-ffm/blob/f76df973af0be086217f32efc9d9c80b06f088fb/.github/workflows/backport.yml
- [x] https://github.com/freifunkMUC/site-ffm/blob/f76df973af0be086217f32efc9d9c80b06f088fb/.github/workflows/update-targets.yml


Example PR User:
![image](https://github.com/user-attachments/assets/d9b9561c-8e1d-47a2-adc5-317288de6ad1)

Fürs Bot Logo können wir folgendes verwenden:
![image](https://raw.githubusercontent.com/T0biii/logo_merchandise_ci/refs/heads/master/logos/Ffmuc-logo-250-noBackground-upsidedown.png)
https://github.com/freifunkMUC/logo_merchandise_ci/pull/9