### PR TITLE
[Backport gluon-v2021.1.x] build(deps): bump softprops/action-gh-release from 2.0.5 to 2.2.0

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -82,7 +82,7 @@ jobs:
             tar zcvf "${output}.tar.gz" "${output}"
           done
       - name: Create Release & Upload Release Assets
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
         with:
           # Note: If there is no release name specified, releases created in
           # the GitHub UI do not trigger a failure and are modified instead.


### PR DESCRIPTION
# Description
Backport of #524 to `gluon_v2021.1.x`.