### PR TITLE
[gluon-v2021.1.x] github: pin firmware build to ubuntu-22.04

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_target_matrix.outputs.target_json) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Maximize build space
         run: |


### PR DESCRIPTION
This is required for Python2