### PR TITLE
remove "next" autoupdater branch

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -90,7 +90,7 @@ jobs:
           # Note: If there is no release name specified, releases created in
           # the GitHub UI do not trigger a failure and are modified instead.
           draft: false
-          prerelease: true  # "next" should always be a pre-release
+          prerelease: false
           # Note: Release notes are only auto-generated if the release was
           # created by the Github Action and was not created in the Github UI.
           generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ GLUON_TARGETS ?= $(shell cat targets | tr '\n' ' ')
 GLUON_AUTOUPDATER_ENABLED := 1
 
 ifneq (,$(shell git describe --exact-match --tags 2>/dev/null))
-	GLUON_AUTOUPDATER_BRANCH := next
+	GLUON_AUTOUPDATER_BRANCH := stable
 	GLUON_RELEASE := $(shell git describe --tags 2>/dev/null)
 else
-	GLUON_AUTOUPDATER_BRANCH := next
+	GLUON_AUTOUPDATER_BRANCH := experimental
 	EXP_FALLBACK = $(shell date '+%Y%m%d')
 	BUILD_NUMBER ?= exp$(EXP_FALLBACK)
 	GLUON_RELEASE := $(shell git describe --tags)~$(BUILD_NUMBER)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ else # only run for specific gluon devices (works only for a single GLUON_TARGET
 endif
 
 manifest: build
-	for branch in next experimental testing stable; do \
+	for branch in experimental testing stable; do \
 		${GLUON_MAKE} manifest GLUON_AUTOUPDATER_BRANCH=$$branch;\
 	done
 	mv -f ${GLUON_BUILD_DIR}/output/* ./output/

--- a/site.conf
+++ b/site.conf
@@ -53,30 +53,6 @@
     enabled = 1,
     branch = 'stable',
     branches = {
-      next = {
-        name = 'next',
-        mirrors = {
-          'http://firmware.ffmuc.net/next/sysupgrade',
-          'http://5.1.66.255/next/sysupgrade',
-          'http://185.150.99.255/next/sysupgrade',
-          'http://[2001:678:e68:f000::]/next/sysupgrade',
-          'http://[2001:678:ed0:f000::]/next/sysupgrade',
-        },
-        good_signatures = 1,
-        pubkeys = {
-          '6dcfc670a4150e16962c1852066669d9b337f168d0f6a863ed930968c2f047eb', -- awlnx
-          'dc44c9810a0470b2de63990128dbae392a836f4385d23e57eb72880ea8fbcf16', -- django
-          '5700c7a266d80aa1c6c33f29835a7b200bdd500e88ee86c0a63e24a0023364f6', -- krombel
-          '216a34d34a15688e127d8d90e6c57587aa8c682b0648322f68338487657fd5ff', -- lukesix
-          '2a74ed02120a7d48bb2dc9be988b3480ed99844054b3d7f3e5d3df27d19d814b', -- ole
-          '56c4201f6ce2994678b0142e19099dd28d6ed17775d35ca9a7f12d9235890ffc', -- chris
-          '3cc6dc6d0d7499d4d17cacad5f16336634e0b26700807f29cc241eaabbde481f', -- goligo
-          'e7a50df4bc8875113eaf75dff5204e8753a9189baeed40c6db0509398a428820', -- thegoliath
-          '50bafd8216cab2ee1c11c215b528dd7c6396f3edfdab689c70ca04a9f284b931', -- grische
-          'cc7e3a6a4788d4246075923b298634f14a4fd179020ef6369fb74d601f55cc84', -- ff_mgk
-          '18fecc717a237ea5702fb97fa4689f9307d0267e3ee8f09377dbed99397b77b9', -- t0biii
-        },
-      },
       stable = {
         name = 'stable',
         mirrors = {

--- a/site.conf
+++ b/site.conf
@@ -173,9 +173,9 @@
     tq_limit_enabled = false, -- incompatible with Batman V. The offline SSID will only be set if there is no gateway reacheable.
   },
 
-  update_channel = { -- next branch only !!!
-    from_name = false, -- false to catch all
-    to_name = 'next', -- if to_name is defined, autoupdater branch is set to it on upgrade
+  update_channel = {
+    from_name = 'next', -- false to catch all
+    to_name = 'stable', -- if to_name is defined, autoupdater branch is set to it on upgrade
   },
 
   custom_banner = {

--- a/site.conf
+++ b/site.conf
@@ -51,7 +51,7 @@
 
   autoupdater = {
     enabled = 1,
-    branch = 'next',
+    branch = 'stable',
     branches = {
       next = {
         name = 'next',


### PR DESCRIPTION
This should not be required anymore thanks to https://github.com/freifunkMUC/ffmuc-salt-public/pull/165