### PR TITLE
[Backport gluon-v2023.2.x] readme: change Docker tags to use branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,26 @@ make
 ### Containerised building
 
 As the CI is using Ubuntu, only the Ubuntu dependencies are being tracked. To simplify building on other distros, containerised building is also possible:
+
 ```sh
-docker build -t site-ffm-next -f Dockerfile_build .
+docker build -t site-ffm-$(git rev-parse --abbrev-ref HEAD) -f Dockerfile_build .
 ```
+
 This will build the build Docker image. With the following export, the Makefile will then use the repo for building but will run inside an Ubuntu container.\
 **Note**: If the working directory is a git worktree, add a volume mount for the main git folder.
+
 ```sh
 mkdir -p gluon-build output
-docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-next make
+docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-$(git rev-parse --abbrev-ref HEAD) make
 ```
 
 #### Example
+
 Full command for a [lantiq-xrx200](https://github.com/freifunk-gluon/gluon/blob/v2022.1/targets/lantiq-xrx200) build:
 
 ```sh
 mkdir -p logs gluon-build output
-docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-next make V=s GLUON_TARGETS=lantiq-xrx200 |& tee logs/build_lantiq-xrx200_$(date --iso=s).log
+docker run --rm -v $(pwd):/site-ffm:ro -v $(pwd)/gluon-build:/site-ffm/gluon-build:rw -v $(pwd)/output:/site-ffm/output:rw -w /site-ffm -u $UID site-ffm-$(git rev-parse --abbrev-ref HEAD) make V=s GLUON_TARGETS=lantiq-xrx200 |& tee logs/build_lantiq-xrx200_$(date --iso=s).log
 ```
 
 ## Further Resources


### PR DESCRIPTION
Manual backport of https://github.com/freifunkMUC/site-ffm/pull/536