### PR TITLE
[CI] update GITHUB_SHA ENV

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -58,7 +58,7 @@ jobs:
       - name: build target ${{ matrix.target }}
         id: compile
         run: |
-          git checkout -b patched ${GITHUB_SHA}
+          git checkout -b patched ${{ github.event.pull_request.head.sha || github.sha }}
           make BROKEN=1 GLUON_TARGETS=${{ matrix.target }} BUILD_NUMBER=${{ github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || github.run_id && format('run{0}', github.run_id) }} V=s
           echo "status=success" >> $GITHUB_OUTPUT
       - name: Upload firmware ${{ matrix.target }}


### PR DESCRIPTION
fixes #567

Edit:
~~mh scheint doch noch nicht geholfen zu haben
1bef445~~

Sieht gut aus:

```
Run git checkout -b patched ee286f066[1](https://github.com/freifunkMUC/site-ffm/actions/runs/12903784300/job/35979694662#step:5:1)d02509a5a4f891d15130231a9ef484
  git checkout -b patched ee286f0661d0[2](https://github.com/freifunkMUC/site-ffm/actions/runs/12903784300/job/35979694662#step:5:2)509a5a4f891d15130231a9ef484
  make BROKEN=1 GLUON_TARGETS=armsr-armv7 BUILD_NUMBER=pr568 V=s
  echo "status=success" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
Previous HEAD position was 8bc4f5f Merge ee286f0661d02509a5a4f891d151[3](https://github.com/freifunkMUC/site-ffm/actions/runs/12903784300/job/35979694662#step:5:3)0231a9ef484 into ff7f2860d3ed6af4e9ba9cf71fb872e6a1a4c38b
Switched to a new branch 'patched'
#########################
# FFMUC Firmware build
# Building release v202[5](https://github.com/freifunkMUC/site-ffm/actions/runs/12903784300/job/35979694662#step:5:5).1.1-9-gee286f0~pr568 for branch experimental

```
v2025.1.1-9-g**ee286f0**~pr568


Wating for CI, Backports needs to be created manually because of CI change