### PR TITLE
[CI] allow backports of workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,16 +12,19 @@ jobs:
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:
-      - name: Clone Firmware
-        uses: actions/checkout@v4 # v4
-
       - name: Get Github App Token
         uses: actions/create-github-app-token@v1 # v1
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-
+          
+      - name: Clone Firmware
+        uses: actions/checkout@v4 # v4
+        with:
+          # Token for git actions, e.g. git push
+          token: ${{ steps.app-token.outputs.token }}
+          
       - name: Create backport pull requests
         uses: korthout/backport-action@be567af183754f6a5d831ae90f648954763f17f5 # v3.1.0
         with:


### PR DESCRIPTION
the `actions/checkout` needs the github bot token, as this is used for push