### PR TITLE
[Backport gluon-v2021.1.x] build(deps): bump reviewdog/action-shellcheck from 1.18.1 to 1.20.0

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
       - name: shellcheck
         # Make sure the action is pinned to a commit, as all reviewdog repos
         # have hundreds of contributors with write access (breaks easy/often)
-        uses: reviewdog/action-shellcheck@50e5e1e2284575f23a1e409d9c0804cdfc4f6e31  # v1.18.1
+        uses: reviewdog/action-shellcheck@72365a51bf6476fe952a117c3ff703eb7775e40a  # v1.20.0
         with:
           filter_mode: "file"
           fail_on_error: true


### PR DESCRIPTION
Backport of #373 to gluon-v2021.1.x

Bumps [reviewdog/action-shellcheck](https://github.com/reviewdog/action-shellcheck) from 1.18.1 to 1.20.0.
- [Release notes](https://github.com/reviewdog/action-shellcheck/releases)
- [Commits](https://github.com/reviewdog/action-shellcheck/compare/50e5e1e2284575f23a1e409d9c0804cdfc4f6e31...72365a51bf6476fe952a117c3ff703eb7775e40a)

---
updated-dependencies:
- dependency-name: reviewdog/action-shellcheck dependency-type: direct:production update-type: version-update:semver-minor ...