### PR TITLE
bump gluon-main (Cudy TR3000 v1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 373e2b8ee2d8b951028aa85dac4532938dccc142 # gluon main (2025-04-10)
+GLUON_GIT_REF := 84fb35d03c538ad231c23589d820977edc27755d # gluon main (2025-04-25)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
`gluon-mesh-vpn-wireguard: fix shellcheck warnings in netifd proto` 
`mediatek-filogic: add support for Cudy TR3000 v1 (#3473)`
`gluon-core: use single conduit interface for DSA topology`
`generic: enable dnsmasq ed25519 keys regardless of target`
`core: remove transitive option from network interfaces`
`gluon-ebtables-filter-multicast: block packets with Gluon VXLAN multicast destination`
`gluon-mesh-layer3-common: remove deprecated node_client_prefix6 from site`

https://github.com/freifunk-gluon/gluon/compare/373e2b8ee2d8b951028aa85dac4532938dccc142...84fb35d03c538ad231c23589d820977edc27755d

if ci is green auto merge activated