### PR TITLE
github: firmware: add target job for required status checks

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -68,6 +68,21 @@ jobs:
           name: ${{ matrix.target }}_output
           path: ./output
 
+  # Workarround job so that there is a single job for the required status check
+  build_firmware_complete:
+    name: All Targets Build
+    runs-on: ubuntu-22.04
+    if: ${{ !cancelled() }}
+    needs: [build_firmware]
+    steps:
+      - name: Error out if there is a failure
+        if: ${{ needs.build_firmware.result != 'success' }}
+        run: |
+          echo "::error title=X Test failed::Build Matrix Result: ${{ needs.build_firmware.result }}"
+          exit 1
+      - name: All firmware builds succeded
+        run: echo "::notice title=✓ Test passed::All required builds succeded!"
+
   create_release:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Status Checks (at least judging from the docs) don't support jobs without a name as well as job matrixes.

Therefore a single job seems to be required which is run once all builds have been successfull.

This should achieve that.

It can be added as "All Targets Build" in the rulesets.

Then Features like auto merge will wait until all builds have completed until they are executed.

Needs testing. Currently it's mostly a theory but it looks promising: https://github.com/nix-freifunk/site-ffnix/pull/9