### PR TITLE
bump gluon main (GL.iNet GL-MT2500, Cudy TR1200 v1, ASUS RT-AX52, Genexis Pulse EX400)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 8720ce4386905e8b0abd7a885ca089b8de796f52 # gluon main (2025-04-27)
+GLUON_GIT_REF := 480fdf574e1818b30809ef4d03ff9213fdcdb508 # gluon main (2025-05-22)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
bump gluon main (GL.iNet GL-MT2500, Cudy TR1200 v1, ASUS RT-AX52, Genexis Pulse EX400; package/gluon-respondd: add target information)

Full Changelog:
https://github.com/freifunk-gluon/gluon/compare/8720ce4386905e8b0abd7a885ca089b8de796f52...480fdf574e1818b30809ef4d03ff9213fdcdb508