### PR TITLE
add missing xzcat build dependency

### DIFF
--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -43,4 +43,5 @@ apt-get -y --no-install-recommends install \
     swig \
     tar \
     unzip \
-    wget
+    wget \
+    xz-utils


### PR DESCRIPTION
Latest version of Gluon requires xzcat for at least ipq806x-generic.

We never noticed because our runners already contain it:
```
xz-utils is already the newest version (5.6.1+really5.4.5-1ubuntu0.2).
```

At far as I can tell, it is not needed for other branches.