### PR TITLE
add node-whisperer to all sites

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -23,6 +23,7 @@ packages{
     'ffac-change-autoupdater',
     'ffac-ssid-changer',
     'ffbs-collect-debug-info',
+    'ffda-node-whisperer',
     'ffmuc-ipv6-ra-filter',
     'ffmuc-mesh-vpn-wireguard-vxlan',
     'iwinfo',

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -198,8 +198,8 @@ if target('bcm27xx') then
 end
 
 if target('ramips', 'mt7621') or target('mediatek', 'mt7622') or target('mediatek', 'filogic') then
-	-- restart device if mt7915e driver shows known failure symptom
-	packages {
-		'ffac-mt7915-hotfix',
-	}
+    -- restart device if mt7915e driver shows known failure symptom
+    packages {
+        'ffac-mt7915-hotfix',
+    }
 end

--- a/site.conf
+++ b/site.conf
@@ -156,4 +156,18 @@
     map_url     = 'https://map.ffmuc.net/#!/',  -- optional (skipped by default)
     contact_url = 'https://ffmuc.net/kontakt/', -- optional (skipped by default)
   },
+
+  node_whisperer = {
+    enabled = true,
+    information = {
+      'hostname',
+      'node_id',
+      'uptime',
+      'site_code',
+      'domain',
+      'system_load',
+      'firmware_version',
+      -- 'batman_adv', Batman V is not yet supported, see https://github.com/freifunk-darmstadt/node-whisperer/issues/2
+    },
+  },
 }


### PR DESCRIPTION
Get the Android App node-monitor to see information about your APs easily from your mobile phone:
https://github.com/freifunk-darmstadt/NodeMonitor


## Screenshots

<img src="https://raw.githubusercontent.com/freifunk-darmstadt/NodeMonitor/refs/heads/master/metadata/en-US/images/phoneScreenshots/overview.png" width="32.5%">
<img src="https://raw.githubusercontent.com/freifunk-darmstadt/NodeMonitor/refs/heads/master/metadata/en-US/images/phoneScreenshots/nodeinfo_half.png" width="32.5%">
<img src="https://raw.githubusercontent.com/freifunk-darmstadt/NodeMonitor/refs/heads/master/metadata/en-US/images/phoneScreenshots/nodeinfo_full.png" width="32.5%">