### PR TITLE
Remove draft from bump modules

### DIFF
--- a/.github/workflows/bump-modules.yml
+++ b/.github/workflows/bump-modules.yml
@@ -50,7 +50,6 @@ jobs:
             [1]: https://github.com/peter-evans/create-pull-request
           branch: ${{ steps.branch-name.outputs.branch-name }}
           labels: ${{ github.ref_name }}
-          draft: true # this step does not trigger a CI run, so always mark them as draft
           delete-branch: true
 
       - name: Check outputs


### PR DESCRIPTION
I think the pipeline will still start running as we have switched to the bot account should be the same as for the Backport workflow