### PR TITLE
gluon-main: bump Gluon to latest main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 240a3b3c39237684d59f28f4a9b6827e4a7fe366 # gluon main (2025-08-04)
+GLUON_GIT_REF := 6d3ceffce2fd866dc1b71f65ff7151b3720ffdc8 # gluon main (2025-08-12)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 3b8dff367dcc56f4264e86c346568414d56e66b9 # gluon main (2025-07-28)
+GLUON_GIT_REF := 240a3b3c39237684d59f28f4a9b6827e4a7fe366 # gluon main (2025-08-04)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 6d3ceffce2fd866dc1b71f65ff7151b3720ffdc8 # gluon main (2025-08-12)
+GLUON_GIT_REF := e00940ef53e55098e995b6e0329723077fe1cede # gluon main (2025-08-18)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/targets
+++ b/targets
@@ -19,6 +19,7 @@ mediatek-filogic
 mediatek-mt7622
 mpc85xx-p1010
 mpc85xx-p1020
+mvebu-cortexa53
 mvebu-cortexa9
 ramips-mt7620
 ramips-mt7621


### PR DESCRIPTION
includes
- Xiaomi AX3000T
- TP-Link CPE710-v2
- allow setting hop_penalty in network
- openwrt hostapd: disable WPS button handling
- improve has_default_gw4 for parker
- mvebu-cortexa53: add support for GL.iNet GL-MV1000
- modules: update routing
- modules: update packages
- modules: update openwrt
