### PR TITLE
bump Gluon to latest main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := e00940ef53e55098e995b6e0329723077fe1cede # gluon main (2025-08-18)
+GLUON_GIT_REF := 124b0acd23952dea57fc1ec63020ff137ddd0097 # gluon main (2025-10-06)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -154,6 +154,7 @@ if device({
     'tp-link-archer-c2-v1',
     'tp-link-archer-c20-v1',
     'tp-link-archer-c20i',
+    'tp-link-archer-c50-v6-ca-eu-ru',
     'tp-link-td-w8970',
     'tp-link-td-w8980',
     'tp-link-tl-wr902ac-v1',


### PR DESCRIPTION
highlight:
- ramips-mt76x8: add support for TP-Link Archer C50 v6
- update openwrt base
- gluon-client-bridge: provide owe with its correct wifi mac
- gluon-radvd: Allow lifetime configuration in site
- gluon-mesh-batman-adv: fix has_default_gw4 (ssid-changer always showing the offline SSID on current gluon main)
