### PR TITLE
patches: add support for aruba ap325

### DIFF
--- a/patches/0001-openwrt-add-support-for-aruba-ap32x.patch
+++ b/patches/0001-openwrt-add-support-for-aruba-ap32x.patch
@@ -1,0 +1,1402 @@
+From 88e3d0dee3a52ef683bd14ae2200f1db4550806a Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Tue, 16 Jun 2026 18:58:24 +0000
+Subject: [PATCH 1/2] openwrt: add support for aruba-ap32x
+
+---
+ ...ort-rootfs_data-on-its-own-partition.patch | 178 ++++
+ ...e-name-collision-between-kernel-UBI-.patch |  35 +
+ ...016-ipq806x-add-CONFIG_GPIO_WATCHDOG.patch |  29 +
+ ...ipq806x-add-support-for-Aruba-AP-32x.patch | 990 ++++++++++++++++++
+ ...pq806x-add-apboot-package-for-AP-32x.patch | 119 +++
+ 5 files changed, 1351 insertions(+)
+ create mode 100644 patches/openwrt/0014-base-files-support-rootfs_data-on-its-own-partition.patch
+ create mode 100644 patches/openwrt/0015-base-files-handle-name-collision-between-kernel-UBI-.patch
+ create mode 100644 patches/openwrt/0016-ipq806x-add-CONFIG_GPIO_WATCHDOG.patch
+ create mode 100644 patches/openwrt/0017-ipq806x-add-support-for-Aruba-AP-32x.patch
+ create mode 100644 patches/openwrt/0018-ipq806x-add-apboot-package-for-AP-32x.patch
+
+diff --git a/patches/openwrt/0014-base-files-support-rootfs_data-on-its-own-partition.patch b/patches/openwrt/0014-base-files-support-rootfs_data-on-its-own-partition.patch
+new file mode 100644
+index 00000000..dd2ebfba
+--- /dev/null
++++ b/patches/openwrt/0014-base-files-support-rootfs_data-on-its-own-partition.patch
+@@ -0,0 +1,178 @@
++From 5e8e3ea33bc780505ee115e2012c028998fc20b2 Mon Sep 17 00:00:00 2001
++From: Lukas Stockner <lukas@lukasstockner.de>
++Date: Sat, 2 May 2026 19:31:43 +0200
++Subject: [PATCH 1/5] base-files: support rootfs_data on its own partition
++
++The current code assumes that the rootfs_data UBI volume is on the same MTD
++partition as the rootfs.
++Unfortunately, this does not work on the Aruba AP-325 (and variants), since
++the bootloader enforces a particular UBI volume layout.
++
++Therefore, this adds a separate variable to set the rootfs_data partition,
++and updates all existing devices with a non-default rootfs partition to also
++specify the new variable.
++
++Signed-off-by: Lukas Stockner <lukas@lukasstockner.de>
++---
++ package/base-files/files/lib/upgrade/nand.sh  | 40 +++++++++----------
++ .../base-files/lib/upgrade/platform.sh        |  1 +
++ .../base-files/lib/upgrade/platform.sh        |  1 +
++ .../base-files/lib/upgrade/platform.sh        |  3 ++
++ 4 files changed, 25 insertions(+), 20 deletions(-)
++
++diff --git a/package/base-files/files/lib/upgrade/nand.sh b/package/base-files/files/lib/upgrade/nand.sh
++index ca302557c8..bfe6027f24 100644
++--- a/package/base-files/files/lib/upgrade/nand.sh
+++++ b/package/base-files/files/lib/upgrade/nand.sh
++@@ -7,8 +7,9 @@
++ CI_KERNPART="${CI_KERNPART:-kernel}"
++ 
++ # 'ubi' partition on NAND contains UBI
++-# There are also CI_KERN_UBIPART and CI_ROOT_UBIPART if kernel
++-# and rootfs are on separated UBIs.
+++# If individual UBI volumes are on different partitions,
+++# they can be set with CI_KERN_UBIPART, CI_ROOT_UBIPART and/or
+++# CI_DATA_UBIPART.
++ CI_UBIPART="${CI_UBIPART:-ubi}"
++ 
++ # 'rootfs' UBI volume on NAND contains the rootfs
++@@ -77,9 +78,10 @@ identify_if_gzip() {
++ }
++ 
++ nand_restore_config() {
++-	local ubidev=$( nand_find_ubi "${CI_ROOT_UBIPART:-$CI_UBIPART}" )
+++	local ubidev=$( nand_find_ubi "${CI_DATA_UBIPART:-$CI_UBIPART}" )
++ 	local ubivol="$( nand_find_volume $ubidev rootfs_data )"
++ 	if [ ! "$ubivol" ]; then
+++		local ubidev=$( nand_find_ubi "${CI_ROOT_UBIPART:-$CI_UBIPART}" )
++ 		ubivol="$( nand_find_volume $ubidev "$CI_ROOTPART" )"
++ 		if [ ! "$ubivol" ]; then
++ 			echo "cannot find ubifs data volume"
++@@ -188,23 +190,21 @@ nand_upgrade_prepare_ubi() {
++ 	local has_env="${4:-0}"
++ 	local kern_ubidev
++ 	local root_ubidev
+++	local data_ubidev
++ 
++ 	[ -n "$rootfs_length" -o -n "$kernel_length" ] || return 1
++ 
++-	if [ -n "$CI_KERN_UBIPART" -a -n "$CI_ROOT_UBIPART" ]; then
++-		kern_ubidev="$( nand_attach_ubi "$CI_KERN_UBIPART" "$has_env" )"
++-		[ -n "$kern_ubidev" ] || return 1
++-		root_ubidev="$( nand_attach_ubi "$CI_ROOT_UBIPART" )"
++-		[ -n "$root_ubidev" ] || return 1
++-	else
++-		kern_ubidev="$( nand_attach_ubi "$CI_UBIPART" "$has_env" )"
++-		[ -n "$kern_ubidev" ] || return 1
++-		root_ubidev="$kern_ubidev"
++-	fi
+++	# Attach UBI partitions (might be identical, but nand_attach_ubi handles that)
+++	kern_ubidev="$( nand_attach_ubi "${CI_KERN_UBIPART:-$CI_UBIPART}" "$has_env" )"
+++	[ -n "$kern_ubidev" ] || return 1
+++	root_ubidev="$( nand_attach_ubi "${CI_ROOT_UBIPART:-$CI_UBIPART}" )"
+++	[ -n "$root_ubidev" ] || return 1
+++	data_ubidev="$( nand_attach_ubi "${CI_DATA_UBIPART:-$CI_UBIPART}" )"
+++	[ -n "$data_ubidev" ] || return 1
++ 
++ 	local kern_ubivol="$( nand_find_volume $kern_ubidev "$CI_KERNPART" )"
++ 	local root_ubivol="$( nand_find_volume $root_ubidev "$CI_ROOTPART" )"
++-	local data_ubivol="$( nand_find_volume $root_ubidev rootfs_data )"
+++	local data_ubivol="$( nand_find_volume $data_ubidev rootfs_data )"
++ 	[ "$root_ubivol" = "$kern_ubivol" ] && root_ubivol=
++ 
++ 	# remove ubiblocks
++@@ -215,7 +215,7 @@ nand_upgrade_prepare_ubi() {
++ 	# kill volumes
++ 	[ "$kern_ubivol" ] && ubirmvol /dev/$kern_ubidev -N "$CI_KERNPART" || :
++ 	[ "$root_ubivol" ] && ubirmvol /dev/$root_ubidev -N "$CI_ROOTPART" || :
++-	[ "$data_ubivol" ] && ubirmvol /dev/$root_ubidev -N rootfs_data || :
+++	[ "$data_ubivol" ] && ubirmvol /dev/$data_ubidev -N rootfs_data || :
++ 
++ 	# create kernel vol
++ 	if [ -n "$kernel_length" ]; then
++@@ -245,8 +245,8 @@ nand_upgrade_prepare_ubi() {
++ 		if [ -n "$rootfs_data_max" ]; then
++ 			rootfs_data_size_param="-s $rootfs_data_max"
++ 		fi
++-		if ! ubimkvol /dev/$root_ubidev -N rootfs_data $rootfs_data_size_param; then
++-			if ! ubimkvol /dev/$root_ubidev -N rootfs_data -m; then
+++		if ! ubimkvol /dev/$data_ubidev -N rootfs_data $rootfs_data_size_param; then
+++			if ! ubimkvol /dev/$data_ubidev -N rootfs_data -m; then
++ 				echo "cannot initialize rootfs_data volume"
++ 				return 1
++ 			fi
++@@ -278,8 +278,8 @@ nand_upgrade_ubifs() {
++ 
++ 	nand_upgrade_prepare_ubi "$ubifs_length" "ubifs" "" "" || return 1
++ 
++-	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
++-	local root_ubivol="$(nand_find_volume $ubidev "$CI_ROOTPART")"
+++	local root_ubidev="$( nand_find_ubi "${CI_ROOT_UBIPART:-$CI_UBIPART}" )"
+++	local root_ubivol="$(nand_find_volume $root_ubidev "$CI_ROOTPART")"
++ 	$cmd < "$ubifs_file" | ubiupdatevol /dev/$root_ubivol -s "$ubifs_length" -
++ }
++ 
++@@ -292,7 +292,7 @@ nand_upgrade_fit() {
++ 
++ 	nand_upgrade_prepare_ubi "" "" "$fit_length" "1" || return 1
++ 
++-	local fit_ubidev="$(nand_find_ubi "$CI_UBIPART")"
+++	local fit_ubidev="$(nand_find_ubi "${CI_KERN_UBIPART:-$CI_UBIPART}")"
++ 	local fit_ubivol="$(nand_find_volume $fit_ubidev "$CI_KERNPART")"
++ 	$cmd < "$fit_file" | ubiupdatevol /dev/$fit_ubivol -s "$fit_length" -
++ }
++diff --git a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
++index 8af61b0289..a589db3a8f 100755
++--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
++@@ -179,6 +179,7 @@ platform_do_upgrade() {
++ 	xiaomi,redmi-router-ax6000-stock)
++ 		CI_KERN_UBIPART=ubi_kernel
++ 		CI_ROOT_UBIPART=ubi
+++		CI_DATA_UBIPART=ubi
++ 		nand_do_upgrade "$1"
++ 		;;
++ 	*)
++diff --git a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
++index 13d8e77c93..185c19afc4 100755
++--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
++@@ -29,6 +29,7 @@ platform_do_upgrade() {
++ 		CI_KERNPART=boot
++ 		CI_KERN_UBIPART=ubi_kernel
++ 		CI_ROOT_UBIPART=ubi
+++		CI_DATA_UBIPART=ubi
++ 		nand_do_upgrade "$1"
++ 		;;
++ 	buffalo,ls421de|\
++diff --git a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
++index 871f29e902..f3049b782b 100644
++--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
++@@ -187,6 +187,7 @@ platform_do_upgrade() {
++ 	buffalo,wxr-5950ax12)
++ 		CI_KERN_UBIPART="rootfs"
++ 		CI_ROOT_UBIPART="user_property"
+++		CI_DATA_UBIPART="user_property"
++ 		buffalo_upgrade_prepare
++ 		nand_do_flash_file "$1" || nand_do_upgrade_failed
++ 		nand_do_restore_config || nand_do_upgrade_failed
++@@ -245,6 +246,7 @@ platform_do_upgrade() {
++ 		# Kernel and rootfs are placed in 2 different UBI
++ 		CI_KERN_UBIPART="ubi_kernel"
++ 		CI_ROOT_UBIPART="rootfs"
+++		CI_DATA_UBIPART="rootfs"
++ 		nand_do_upgrade "$1"
++ 		;;
++ 	spectrum,sax1v1k)
++@@ -283,6 +285,7 @@ platform_do_upgrade() {
++ 	zte,mf269)
++ 		CI_KERN_UBIPART="ubi_kernel"
++ 		CI_ROOT_UBIPART="rootfs"
+++		CI_DATA_UBIPART="rootfs"
++ 		nand_do_upgrade "$1"
++ 		;;
++ 	zyxel,nbg7815)
++-- 
++2.43.0
++
+diff --git a/patches/openwrt/0015-base-files-handle-name-collision-between-kernel-UBI-.patch b/patches/openwrt/0015-base-files-handle-name-collision-between-kernel-UBI-.patch
+new file mode 100644
+index 00000000..36ff9493
+--- /dev/null
++++ b/patches/openwrt/0015-base-files-handle-name-collision-between-kernel-UBI-.patch
+@@ -0,0 +1,35 @@
++From 16ceb91573f0bdf60bcdb0b897a512f00f8873f6 Mon Sep 17 00:00:00 2001
++From: Lukas Stockner <lukas@lukasstockner.de>
++Date: Sat, 2 May 2026 19:32:23 +0200
++Subject: [PATCH 2/5] base-files: handle name collision between kernel UBI
++ volume and MTD partition
++
++On the AP-325 (and variants), the bootloader enforces a particular UBI volume
++layout and naming, so unfortunately the kernel's UBI volume and MTD partition
++end up with the name, which confuses the current logic.
++
++Therefore, add an option to ignore the MTD partition.
++
++Signed-off-by: Lukas Stockner <lukas@lukasstockner.de>
++---
++ package/base-files/files/lib/upgrade/nand.sh | 4 ++++
++ 1 file changed, 4 insertions(+)
++
++diff --git a/package/base-files/files/lib/upgrade/nand.sh b/package/base-files/files/lib/upgrade/nand.sh
++index bfe6027f24..0faa034934 100644
++--- a/package/base-files/files/lib/upgrade/nand.sh
+++++ b/package/base-files/files/lib/upgrade/nand.sh
++@@ -318,6 +318,10 @@ nand_upgrade_tar() {
++ 	local rootfs_type
++ 	[ "$rootfs_length" ] && rootfs_type="$(identify_tar "$tar_file" "$cmd" "$board_dir/root")"
++ 
+++	# If CI_SKIP_KERNEL_MTD is set, ignore any potential kernel MTD partition that was found.
+++	# This is needed if there's an MTD partition with the same name as the kernel's UBI volume.
+++	[ "${CI_SKIP_KERNEL_MTD:-}" ] && kernel_mtd=
+++
++ 	local ubi_kernel_length
++ 	if [ "$kernel_length" ]; then
++ 		if [ "$kernel_mtd" ]; then
++-- 
++2.43.0
++
+diff --git a/patches/openwrt/0016-ipq806x-add-CONFIG_GPIO_WATCHDOG.patch b/patches/openwrt/0016-ipq806x-add-CONFIG_GPIO_WATCHDOG.patch
+new file mode 100644
+index 00000000..7a373d4a
+--- /dev/null
++++ b/patches/openwrt/0016-ipq806x-add-CONFIG_GPIO_WATCHDOG.patch
+@@ -0,0 +1,29 @@
++From 9e8b885f95b24e2e464fb6d66894280389edad39 Mon Sep 17 00:00:00 2001
++From: Lukas Stockner <lukas@lukasstockner.de>
++Date: Sat, 2 May 2026 20:11:04 +0200
++Subject: [PATCH 3/5] ipq806x: add CONFIG_GPIO_WATCHDOG
++
++The AP-325 (and variants) has an external watchdog, so this is needed to
++regularly toggle the GPIO and keep the watchdog happy.
++
++Signed-off-by: Lukas Stockner <lukas@lukasstockner.de>
++---
++ target/linux/ipq806x/config-6.6 | 2 ++
++ 1 file changed, 2 insertions(+)
++
++diff --git a/target/linux/ipq806x/config-6.6 b/target/linux/ipq806x/config-6.6
++index 7e9558ad75..59ab8b3c05 100644
++--- a/target/linux/ipq806x/config-6.6
+++++ b/target/linux/ipq806x/config-6.6
++@@ -184,6 +184,8 @@ CONFIG_GENERIC_VDSO_32=y
++ CONFIG_GLOB=y
++ CONFIG_GPIOLIB_IRQCHIP=y
++ CONFIG_GPIO_CDEV=y
+++CONFIG_GPIO_WATCHDOG=y
+++CONFIG_GPIO_WATCHDOG_ARCH_INITCALL=y
++ CONFIG_GRO_CELLS=y
++ CONFIG_HARDEN_BRANCH_PREDICTOR=y
++ CONFIG_HARDIRQS_SW_RESEND=y
++-- 
++2.43.0
++
+diff --git a/patches/openwrt/0017-ipq806x-add-support-for-Aruba-AP-32x.patch b/patches/openwrt/0017-ipq806x-add-support-for-Aruba-AP-32x.patch
+new file mode 100644
+index 00000000..35bfd528
+--- /dev/null
++++ b/patches/openwrt/0017-ipq806x-add-support-for-Aruba-AP-32x.patch
+@@ -0,0 +1,990 @@
++From d0a70497a5f1765d23f09df02c504de29014a8ab Mon Sep 17 00:00:00 2001
++From: Lukas Stockner <lukas@lukasstockner.de>
++Date: Wed, 5 Nov 2025 23:41:57 +0100
++Subject: [PATCH 4/5] ipq806x: add support for Aruba AP-32x
++
++This is a dual-radio 802.11a/b/g/n/ac access point with
++dual Gigabit Ethernet.
++
++There are two closely related models: The AP-324, which has external
++antenna connectors, and the AP-325, which has internal antennas.
++The board appears to be identical, and the same image works on both.
++Additionally, the Siemens Scalance W1750D is an OEM variant using
++the same board, so the image also works on that.
++
++Unfortunately the factory APBoot bootloader enforces cryptographic
++signatures on the firmware before booting, so a modified version
++must be flashed via the serial port. See [^1] for details.
++
++Specifications
++==============
++* Device:       Aruba AP-325 / AP-324
++* SoC:          Qualcomm IPQ8068 2x1.4GHz ARMv7-A
++* RAM:          512MiB (2x Winbond W632GU6MB-12)
++* SPI flash:    4MiB Macronix MX25U3235F
++* NAND flash:   128MiB Winbond W29N01HZBINF
++* WiFi:         2x Qualcomm QCA9990 (one 2.4G, one 5G)
++* Ethernet:     2x 1000BASE-T (Marvell 88E1514 PHY), both PoE-capable
++* Power:        PoE 802.3at or 12V DC jack
++* LEDs:         Red/Amber/Green status LED, Amber/Green WiFi LED
++* Buttons:      1x, behind hole next to DC jack
++* Console:      RJ45 connector, Cisco pinout
++* USB:          1x USB 2.0 Type A, 1x internal to BLE, SoC has USB 3.0
++                host but board is only wired for 2.0
++* BLE:          TI CC2540 SoC, connected to USB and UART, unpopulated
++                debug header on PCB
++* TPM:          Atmel AT97SC3205T
++
++How to install
++==============
++The stock bootloader APBoot appears to be vendor fork of U-Boot, which
++disables much of the usual functionality and comes with its own booting
++and firmware upgrade logic.
++
++Unfortunately, this logic enforces RSA signatures on images,
++even for the default boot from NAND.
++
++Therefore, a patched bootloader is needed, which is built as a package.
++In addition to the signature check removal, this also changes
++the serial baudrate to 115200.
++
++Luckily, the stock firmware does not disable the `sf` command
++(it just hides it until you run `diag`), so the patched bootloader
++can be fetched via TFTP and then flashed via console.
++
++Flashing patched APBoot
++-----------------------
++* Build OpenWrt, or download `openwrt-ipq806x-generic-aruba_ap-32x-apboot.mbn`
++* Connect serial cable and wired ethernet
++* Access stock APBoot console at Baud 9600
++* Flash patched bootloader:
++```
++setenv serverip <your TFTP server IP>
++setenv autostart n
++netget 44000000 openwrt-ipq806x-generic-aruba_ap-32x-apboot.mbn
++sf probe 0
++sf erase 220000 100000
++sf write 44000000 220000 100000
++reset
++```
++
++Booting OpenWrt
++---------------
++* Connect serial cable and wired ethernet
++* Access patched APBoot console at Baud 115200
++* Run `setenv serverip <your TFTP server IP>`
++* Run `tftpboot openwrt-ipq806x-generic-aruba_ap-32x-initramfs.ari`
++
++Installing OpenWrt
++------------------
++* Connect serial cable and wired ethernet
++* Access patched APBoot console at Baud 115200
++* Consider backing up stock firmware(s) (UBI volumes `aos0` and/or `aos1`)
++  by booting into OpenWrt via initramfs (see above) and dumping them
++* Wipe and repartition NAND flash (see below for explanation):
++```
++nand device 0
++nand erase.chip
++reset
++ubi part ubifs
++ubi remove ubifs
++ubi create ubifs 1
++ubi create rootfs_data
++```
++* Follow steps above to boot OpenWrt via initramfs
++* From OpenWrt, persist installation via sysupgrade
++
++Reverting to stock FW
++---------------------
++
++The patched bootloader remains compatible with the original firmware,
++so you can just wipe the NAND, let APBoot recreate the partitions,
++and flash back the `aos0`/`aos1` backup from above.
++
++Current status
++==============
++
++Tested and working
++------------------
++
++* Console
++* Wired GbE (both ports)
++* WiFi (both 2.4G and 5G)
++* LEDs
++* Restart Button
++* USB port
++* External watchdog
++* TPM
++* BLE SoC
++
++Future work
++-----------
++
++* GPIOs for:
++  * power source (8 indicates DC jack, 59 indicates 802.3at)
++  * reset source (64 for warm reset, 65 for watchdog)
++  * USB overcurrent (63)
++* BLE SoC reflashing
++  * CC2540 comes with Aruba-specific FW out of the box
++  * Debug header is exposed on PCB (pinout GND-VCC-Clock-Data-Reset),
++    but that requires disassembly
++  * Stock BLE FW appears to support reflashing via UART, but protocol
++    would need to be reverse-engineered
++* ramoops/pstore
++  * It appears that APBoot clears the RAM on boot, might be something
++    we can patch out as well
++* Porting a modern U-Boot
++
++Flash layout
++============
++
++SPI flash
++---------
++
++```
++0x000000-0x020000 sbl1
++0x020000-0x040000 mibib
++0x040000-0x080000 sbl2
++0x080000-0x100000 sbl3
++0x100000-0x110000 ddrconfig
++0x110000-0x120000 ssd
++0x120000-0x1a0000 tz
++0x1a0000-0x220000 rpm
++0x220000-0x320000 appsbl
++0x320000-0x330000 appsblenv
++0x330000-0x370000 art
++0x370000-0x380000 panicdump
++0x380000-0x390000 certificate
++0x390000-0x3a0000 mfginfo
++0x3a0000-0x3b0000 flashcache
++0x3b0000-0x400000 aosspare
++```
++
++Factory NAND flash
++------------------
++* 32MiB MTD partition `aos0`, formatted as UBI
++  * 32MiB UBI volume `aos0`
++    * contains kernel+initrd of the primary firmware,
++      initrd contains the entire root FS
++* 32MiB MTD partition `aos1`, formatted as UBI
++  * 32MiB UBI volume `aos1`
++    * contains kernel+initrd of the secondary firmware,
++      initrd contains the entire root FS
++* 64MiB MTD partition `ubifs`, formatted as UBI
++  * 64MiB UBI volume `ubifs`
++    * Contains UBIFS, overlay-mounted on top of the initrd,
++      shared between firmware slots
++
++APBoot understands UBI, and will read the kernel from the
++`aos0` or `aos1` volume (depending on `os_partition`)
++with fallback to the other one in case a check fails.
++
++Kernels are expected to have a vendor-specific header, the included
++script will add that header with the correct checksum but no signature.
++
++OpenWrt NAND flash
++------------------
++
++OpenWrt assumes separate UBI volumes for kernel and rootfs,
++as well as a volume that must be named `rootfs_data` for the UBIFS.
++
++Unfortunately, APBoot actively checks the UBI volumes at boot, and will
++repartition if it doesn't find the volumes that it expects (listed above).
++
++Luckily, it doesn't check their size, only their existence. Therefore,
++we can use the following layout:
++
++* 32MiB MTD partition `aos0`, formatted as UBI
++  * 32MiB UBI volume `aos0`
++    * contains OpenWrt kernel+initrd
++* 32MiB MTD partition `aos1`, formatted as UBI
++  * 32MiB UBI volume `aos1`
++    * contains OpenWrt root squashfs
++* 64MiB MTD partition `ubifs`, formatted as UBI
++  * small (single-LEB) UBI volume `ubifs`
++    * Dummy volume, only there to satisfy APBoot
++  * almost 64MiB UBI volume `rootfs_data`
++    * contains UBIFS, overlay-mounted on top of the rootfs
++
++[^1]: https://github.com/lukasstockner/ap325-apboot-openwrt
++
++Signed-off-by: Lukas Stockner <lukas@lukasstockner.de>
++---
++ package/boot/uboot-envtools/files/ipq806x     |   6 +
++ scripts/aruba-header.py                       | 225 ++++++++++
++ .../ipq806x/base-files/etc/board.d/02_network |   9 +-
++ .../ipq806x/base-files/etc/init.d/bootcount   |   7 +-
++ .../base-files/lib/upgrade/platform.sh        |  15 +
++ .../arm/boot/dts/qcom/qcom-ipq8068-ap-32x.dts | 387 ++++++++++++++++++
++ target/linux/ipq806x/image/generic.mk         |  31 ++
++ 7 files changed, 673 insertions(+), 7 deletions(-)
++ create mode 100755 scripts/aruba-header.py
++ create mode 100644 target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap-32x.dts
++
++diff --git a/package/boot/uboot-envtools/files/ipq806x b/package/boot/uboot-envtools/files/ipq806x
++index 443a0e13d4..3e653fd30e 100644
++--- a/package/boot/uboot-envtools/files/ipq806x
+++++ b/package/boot/uboot-envtools/files/ipq806x
++@@ -35,6 +35,12 @@ arris,tr4400-v2|\
++ askey,rt4230w-rev6)
++ 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"
++ 	;;
+++aruba,ap-32x|\
+++ignitenet,ss-w2-ac2600|\
+++qcom,ipq8064-ap148|\
+++qcom,ipq8064-db149)
+++	ubootenv_add_uci_config $(ubootenv_mtdinfo)
+++	;;
++ edgecore,ecw5410)
++ 	ubootenv_add_uci_config "/dev/mtd11" "0x0" "0x10000" "0x10000"
++ 	;;
++diff --git a/scripts/aruba-header.py b/scripts/aruba-header.py
++new file mode 100755
++index 0000000000..e7dfa62e14
++--- /dev/null
+++++ b/scripts/aruba-header.py
++@@ -0,0 +1,225 @@
+++#!/usr/bin/python3
+++# SPDX-License-Identifier: GPL-2.0-or-later
+++#
+++# Copyright (C) 2025 Lukas Stockner <lukas@lukasstockner.de>
+++#
+++# ./aruba-header.py <input file> <output file> <build string> <version string> <oem string> <image type> <machine type>
+++#
+++# Generates a header for use with the APBoot bootloader on (some?) Aruba APs.
+++
+++import argparse
+++
+++LEN_BUILD = 256
+++LEN_VERSION = 24
+++LEN_OEM = 32
+++
+++HEADER_MAGIC = b'ARUBA\0\0\0'
+++
+++
+++class ValidFlag:
+++    YES = 1
+++
+++
+++class FormatVersion:
+++    CURRENT = 2
+++
+++
+++class ImageType:
+++    ELF = 0
+++    FPGA_BINARY = 1
+++    CPBOOT_BINARY = 2
+++    APBOOT_BINARY = 3
+++    TPMINFO = 4
+++    APBOOT_STAGE1_BINARY = 5
+++    APBOOT_STAGE2_BINARY = 6
+++    APBOOT_COMBINED_BINARY = 7
+++    OS_ANCILLARY_IMAGE = 8
+++    XLOADER_BINARY = 9
+++    GRUB_BIN = 10
+++    LSM_PACKAGE = 11
+++
+++
+++class CompressionType:
+++    NONE = 0
+++    BZIP2 = 1
+++    GZIP = 2
+++
+++
+++MACHINE_TYPES = {
+++    'MSWITCH': 0,
+++    'CABERNET': 1,
+++    'SYRAH': 2,
+++    'MERLOT': 3,
+++    'MUSCAT': 4,
+++    'NEBBIOLO': 5,
+++    'MALBEC': 6,
+++    'PALOMINO': 7,
+++    'GRENACHE': 8,
+++    'MOSCATO': 9,
+++    'TALISKER': 10,
+++    'JURA_R': 11,
+++    'SCAPA': 12,
+++    'JURA_O': 13,
+++    'CORVINA': 14,
+++    'ARRAN': 15,
+++    'BLUEBLOOD': 16,
+++    'MSR2K': 17,
+++    'PORFIDIO': 18,
+++    'CAZULO': 19,
+++    'SCAPA_H': 20,
+++    'CARDHU': 21,
+++    'BOWMORE': 22,
+++    'TAMDHU': 23,
+++    'ARDBEG': 24,
+++    'ARDMORE': 25,
+++    'DALMORE': 26,
+++    'K2': 27,
+++    'GRAPPA': 28,
+++    'SHUMWAY': 29,
+++    'SPRINGBANK': 30,
+++    'OUZO': 31,
+++    'AMARULA': 32,
+++    'GROZDOVA': 33,
+++    'PALINKA': 34,
+++    'HAZELBURN': 35,
+++    'TOMATIN': 36,
+++    'HAZELBURN_H': 37,
+++    'TOMATIN_16': 38,
+++    'SPRINGBANK_16': 39,
+++    'OCTOMORE': 40,
+++    'BALVENIE': 41,
+++    'OUZO_PLUS': 42,
+++    'X4': 43,
+++    'EINAR': 44,
+++    'GLENFARCLAS': 45,
+++    'GLENFIDDICH': 46,
+++    'EIGER': 47,
+++    'GLENMORANGIE': 48,
+++    'MILAGRO': 49,
+++    'OPUSONE': 50,
+++    'ABERLOUR': 51,
+++    'MILLSTONE': 52,
+++    'DEWARS': 53,
+++    'BUNKER': 54,
+++    'MASTERSON': 55,
+++    'SIERRA': 56,
+++    'KILCHOMAN': 57,
+++    'SPEYBURN': 58,
+++    'LAGAVULIN': 59,
+++    'LAPHROAIG': 60,
+++    'TOBA': 61,
+++    'ARRANTA': 62,
+++}
+++
+++
+++class NextHeader:
+++    NONE = 0x00000000
+++    SIGN = 0x01111111
+++
+++
+++class Flags:
+++    C_TEST_BUILD = 0x00000001
+++    SWATCH = 0x00000002
+++    # Preserves the image with "clear all"
+++    DONT_CLEAR_ON_PURGE = 0x00000004
+++    SECURE_BOOTLOADER = 0x00000008
+++    FACTORY_IMAGE = 0x00000010
+++    FIPS_CERTIFIED = 0x00000020
+++
+++
+++def make_header(data: bytes, build: str, version: str, oem: str, imageType: int, machine: int) -> bytes:
+++    buildBytes = build.encode(encoding='ascii')
+++    assert len(buildBytes) < LEN_BUILD
+++    buildBytes += b'\0' * (LEN_BUILD - len(buildBytes))
+++
+++    versionBytes = version.encode(encoding='ascii')
+++    assert len(versionBytes) < LEN_VERSION
+++    versionBytes += b'\0' * (LEN_VERSION - len(versionBytes))
+++
+++    oemBytes = oem.encode(encoding='ascii')
+++    assert len(oemBytes) < LEN_OEM
+++    oemBytes += b'\0' * (LEN_OEM - len(oemBytes))
+++
+++    header = b''
+++    # Payload size, image plus optional signature (which we don't use)
+++    header += len(data).to_bytes(4, 'big')
+++    # Use what appears to be the current version
+++    header += FormatVersion.CURRENT.to_bytes(4, 'big')
+++    # Checksum is computed later
+++    header += b'\0\0\0\0'
+++    # Vendor magic number
+++    header += HEADER_MAGIC
+++    # Long build information string
+++    header += buildBytes
+++    # Short version information string
+++    header += versionBytes
+++    # Image is valid
+++    header += ValidFlag.YES.to_bytes(1, 'big')
+++    # Image type
+++    header += imageType.to_bytes(1, 'big')
+++    # APBoot doesn't appear to actually support compression
+++    header += CompressionType.NONE.to_bytes(1, 'big')
+++    # Machine type
+++    header += machine.to_bytes(1, 'big')
+++    # Image size
+++    header += len(data).to_bytes(4, 'big')
+++    # Next header (we don't support signing)
+++    header += NextHeader.NONE.to_bytes(4, 'big')
+++    # MD5 checksum plus fudge factor (to ensure non-zero hash), appears unused
+++    header += b'\0' * 16
+++    header += b'\0' * 4
+++    # No flags are set
+++    header += int(0).to_bytes(4, 'big')
+++    # No next header is used
+++    header += b'\0' * 12
+++    # Padding
+++    header += b'\0' * 36
+++    # OEM string
+++    header += oemBytes
+++    # Padding
+++    header += b'\0' * 96
+++
+++    assert len(header) == 512
+++    assert len(data) % 4 == 0
+++
+++    # Compute checksum such that the big-endian sum of all 32-bit integers becomes zero.
+++    curSum = sum(int.from_bytes(header[i : i + 4], 'big') for i in range(0, 512, 4))
+++    curSum += sum(int.from_bytes(data[i : i + 4], 'big') for i in range(0, len(data), 4))
+++
+++    # Set checksum
+++    checksum = 0x100000000 - (curSum % 0x100000000)
+++    header = header[:8] + checksum.to_bytes(4, 'big') + header[12:]
+++
+++    return header
+++
+++
+++if __name__ == "__main__":
+++    parser = argparse.ArgumentParser(description='Generate Aruba header.')
+++    parser.add_argument('source')
+++    parser.add_argument('dest')
+++    parser.add_argument('build')
+++    parser.add_argument('version')
+++    parser.add_argument('oem')
+++    parser.add_argument('type', choices=['os', 'boot'])
+++    parser.add_argument('machine', choices=MACHINE_TYPES.keys(), type=str.upper)
+++    args = parser.parse_args()
+++
+++    # Parse image type.
+++    # The OS image must be type "ELF" even though it's not an ELF file...
+++    imageType = {'os': ImageType.ELF, 'boot': ImageType.APBOOT_BINARY}[args.type]
+++    # Parse machine type.
+++    machineType = MACHINE_TYPES[args.machine]
+++
+++    source = open(args.source, 'rb')
+++    image = source.read()
+++    # Pad image.
+++    if len(image) % 4 != 0:
+++        image += b'\0' * (4 - len(image) % 4)
+++
+++    # Generate header.
+++    header = make_header(image, args.build, args.version, args.oem, imageType, machineType)
+++
+++    # Write output.
+++    dest = open(args.dest, 'wb')
+++    dest.write(header)
+++    dest.write(image)
++diff --git a/target/linux/ipq806x/base-files/etc/board.d/02_network b/target/linux/ipq806x/base-files/etc/board.d/02_network
++index 93ccc961f3..5fe0affadf 100644
++--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
++@@ -14,6 +14,11 @@ ipq806x_setup_interfaces()
++ 	arris,tr4400-v2)
++ 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth2"
++ 		;;
+++	aruba,ap-32x|\
+++	edgecore,ecw5410 |\
+++	extreme,ap3935)
+++		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+++		;;
++ 	askey,rt4230w-rev6 |\
++ 	asrock,g10 |\
++ 	nec,wg2600hp |\
++@@ -47,10 +52,6 @@ ipq806x_setup_interfaces()
++ 		ucidef_set_network_device_conduit "lan1" "eth1"
++ 		ucidef_set_network_device_conduit "wan" "eth0"
++ 		;;
++-	edgecore,ecw5410 |\
++-	extreme,ap3935)
++-		ucidef_set_interfaces_lan_wan "eth1" "eth0"
++-		;;
++ 	qcom,ipq8064-ap161)
++ 		ucidef_set_interface_lan "eth1 eth2 lan1 lan2 lan3 lan4" "wan"
++ 		;;
++diff --git a/target/linux/ipq806x/base-files/etc/init.d/bootcount b/target/linux/ipq806x/base-files/etc/init.d/bootcount
++index ef3c6894e4..81bbb80bc2 100755
++--- a/target/linux/ipq806x/base-files/etc/init.d/bootcount
+++++ b/target/linux/ipq806x/base-files/etc/init.d/bootcount
++@@ -6,12 +6,13 @@ START=99
++ 
++ boot() {
++ 	case $(board_name) in
++-	asrock,g10)
++-		asrock_bootconfig_mangle "bootcheck" && reboot
++-		;;
+++	aruba,ap-32x|\
++ 	edgecore,ecw5410)
++ 		fw_setenv bootcount 0
++ 		;;
+++	asrock,g10)
+++		asrock_bootconfig_mangle "bootcheck" && reboot
+++		;;
++ 	extreme,ap3935)
++ 		fw_setenv WATCHDOG_COUNT 0x00000000
++ 		;;
++diff --git a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
++index f26f118d54..a8a11144db 100644
++--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
++@@ -26,6 +26,21 @@ platform_do_upgrade() {
++ 	qcom,ipq8064-ap161)
++ 		nand_do_upgrade "$1"
++ 		;;
+++	aruba,ap-32x)
+++		# The bootloader on this device unfortunately enforces a particular set of UBI volumes,
+++		# and will mess with the partitioning if it doesn't find it.
+++		# Therefore, we have to make do with the stock layout, which is a set of three
+++		# MTD partitions, each containing a single UBI volume with the same name.
+++		# Luckily, it doesn't check size, so we can have a "rootfs_data" volume next to a dummy
+++		# "ubifs" volume on the "ubifs" partition.
+++		CI_KERNPART="aos0"
+++		CI_ROOTPART="aos1"
+++		CI_KERN_UBIPART="aos0"
+++		CI_ROOT_UBIPART="aos1"
+++		CI_DATA_UBIPART="ubifs"
+++		CI_SKIP_KERNEL_MTD=1
+++		nand_do_upgrade "$1"
+++		;;
++ 	asrock,g10)
++ 		asrock_upgrade_prepare
++ 		nand_do_upgrade "$1"
++diff --git a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap-32x.dts b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap-32x.dts
++new file mode 100644
++index 0000000000..05987c5ee1
++--- /dev/null
+++++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap-32x.dts
++@@ -0,0 +1,387 @@
+++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+++
+++#include "qcom-ipq8064-v2.0.dtsi"
+++
+++#include <dt-bindings/gpio/gpio.h>
+++#include <dt-bindings/input/input.h>
+++#include <dt-bindings/leds/common.h>
+++
+++/ {
+++	model = "Aruba AP-32x";
+++	compatible = "aruba,ap-32x", "qcom,ipq8064";
+++
+++	memory@0 {
+++		reg = <0x41500000 0x1eb00000>;
+++		device_type = "memory";
+++	};
+++
+++	aliases {
+++		serial0 = &gsbi4_serial;
+++		serial1 = &gsbi2_serial;
+++
+++		ethernet0 = &gmac2;
+++		ethernet1 = &gmac3;
+++
+++		led-boot = &led_power_amber;
+++		led-failsafe = &led_power_red;
+++		led-running = &led_power_green;
+++		led-upgrade = &led_power_amber;
+++
+++		label-mac-device = &gmac2;
+++	};
+++
+++	chosen {
+++		stdout-path = "serial0:115200n8";
+++		bootargs-append = " ubi.mtd=aos1 ubi.mtd=ubifs ubi.block=0,aos1 root=/dev/ubiblock0_0";
+++	};
+++
+++	keys {
+++		compatible = "gpio-keys";
+++		pinctrl-0 = <&button_pins>;
+++		pinctrl-names = "default";
+++
+++		reset {
+++			label = "reset";
+++			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_LOW>;
+++			linux,code = <KEY_RESTART>;
+++			debounce-interval = <60>;
+++			wakeup-source;
+++		};
+++	};
+++
+++	leds {
+++		compatible = "gpio-leds";
+++		pinctrl-0 = <&led_pins>;
+++		pinctrl-names = "default";
+++
+++		led_power_green: power_green {
+++			function = LED_FUNCTION_POWER;
+++			color = <LED_COLOR_ID_GREEN>;
+++			gpios = <&qcom_pinmux 28 GPIO_ACTIVE_HIGH>;
+++		};
+++
+++		led_power_amber: power_amber {
+++			function = LED_FUNCTION_POWER;
+++			color = <LED_COLOR_ID_AMBER>;
+++			gpios = <&qcom_pinmux 29 GPIO_ACTIVE_HIGH>;
+++		};
+++
+++		led_power_red: power_red {
+++			function = LED_FUNCTION_POWER;
+++			color = <LED_COLOR_ID_RED>;
+++			gpios = <&qcom_pinmux 30 GPIO_ACTIVE_HIGH>;
+++		};
+++
+++		led_wlan_green {
+++			function = LED_FUNCTION_WLAN;
+++			color = <LED_COLOR_ID_GREEN>;
+++			gpios = <&qcom_pinmux 31 GPIO_ACTIVE_HIGH>;
+++			linux,default-trigger = "phy0tpt";
+++		};
+++
+++		led_wlan_amber {
+++			function = LED_FUNCTION_WLAN;
+++			color = <LED_COLOR_ID_AMBER>;
+++			gpios = <&qcom_pinmux 32 GPIO_ACTIVE_HIGH>;
+++			linux,default-trigger = "phy1tpt";
+++		};
+++	};
+++
+++	watchdog {
+++		compatible = "linux,wdt-gpio";
+++		gpios = <&qcom_pinmux 61 GPIO_ACTIVE_LOW>;
+++		hw_algo = "toggle";
+++		hw_margin_ms = <1000>;
+++		always-running;
+++
+++		pinctrl-names = "default";
+++		pinctrl-0 = <&watchdog_pins>;
+++	};
+++
+++	i2c {
+++		compatible = "i2c-gpio";
+++
+++		sda-gpios = <&qcom_pinmux 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+++		scl-gpios = <&qcom_pinmux 25 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+++
+++		#address-cells = <1>;
+++		#size-cells = <0>;
+++
+++		tpm@29 {
+++			compatible = "atmel,at97sc3204t";
+++			reg = <0x29>;
+++		};
+++	};
+++};
+++
+++&qcom_pinmux {
+++	led_pins: led_pins {
+++		mux {
+++			pins = "gpio28", "gpio29", "gpio30", "gpio31", "gpio32";
+++			function = "gpio";
+++			drive-strength = <12>;
+++			bias-pull-up;
+++		};
+++	};
+++
+++	button_pins: button_pins {
+++		mux {
+++			pins = "gpio9";
+++			function = "gpio";
+++			bias-pull-up;
+++		};
+++	};
+++
+++	uart0_pins: uart0_pins {
+++		mux {
+++			pins = "gpio10", "gpio11";
+++			function = "gsbi4";
+++			drive-strength = <10>;
+++			bias-disable;
+++		};
+++	};
+++
+++	uart1_pins: uart1_pins {
+++		mux {
+++			pins = "gpio22", "gpio23";
+++			function = "gsbi2";
+++			drive-strength = <10>;
+++			bias-disable;
+++		};
+++	};
+++
+++	watchdog_pins: watchdog_pins {
+++		mux {
+++			pins = "gpio61";
+++			function = "gpio";
+++			drive-strength = <10>;
+++			bias-disable;
+++		};
+++	};
+++	/* used for USB over-current detection instead */
+++	/delete-node/ pcie2_pins;
+++};
+++
+++&gsbi4 {
+++	status = "okay";
+++	qcom,mode = <GSBI_PROT_I2C_UART>;
+++};
+++
+++&gsbi4_serial {
+++	status = "okay";
+++	pinctrl-0 = <&uart0_pins>;
+++	pinctrl-names = "default";
+++};
+++
+++&gsbi2 {
+++	status = "okay";
+++	qcom,mode = <GSBI_PROT_I2C_UART>;
+++};
+++
+++&gsbi2_serial {
+++	status = "okay";
+++	pinctrl-0 = <&uart1_pins>;
+++	pinctrl-names = "default";
+++};
+++
+++&gsbi5 {
+++	qcom,mode = <GSBI_PROT_SPI>;
+++	status = "okay";
+++
+++	spi@1a280000 {
+++		status = "okay";
+++		spi-max-frequency = <50000000>;
+++
+++		pinctrl-0 = <&spi_pins>;
+++		pinctrl-names = "default";
+++
+++		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_LOW>;
+++
+++		mx25u3235f@0 {
+++			compatible = "jedec,spi-nor";
+++			#address-cells = <1>;
+++			#size-cells = <1>;
+++			spi-max-frequency = <50000000>;
+++			reg = <0>;
+++
+++			partitions {
+++				compatible = "qcom,smem-part";
+++
+++				partition-art {
+++					compatible = "nvmem-cells";
+++					#address-cells = <1>;
+++					#size-cells = <1>;
+++					label = "0:art";
+++
+++					precal_art_1000: precal@1000 {
+++						reg = <0x1000 0x2f20>;
+++					};
+++
+++					precal_art_5000: precal@5000 {
+++						reg = <0x5000 0x2f20>;
+++					};
+++				};
+++
+++				partition-appsblenv {
+++					label = "0:appsblenv";
+++
+++					nvmem-layout {
+++						compatible = "u-boot,env";
+++
+++						macaddr_lan: ethaddr {
+++							#nvmem-cell-cells = <1>;
+++						};
+++					};
+++				};
+++			};
+++		};
+++	};
+++};
+++
+++&pcie0 {
+++	status = "okay";
+++
+++	bridge@0,0 {
+++		reg = <0x00000000 0 0 0 0>;
+++		#address-cells = <3>;
+++		#size-cells = <2>;
+++		ranges;
+++
+++		wifi@1,0 {
+++			compatible = "qcom,ath10k";
+++			status = "okay";
+++			reg = <0x10000 0 0 0 0>;
+++
+++			nvmem-cells = <&precal_art_1000>;
+++			nvmem-cell-names = "pre-calibration";
+++		};
+++	};
+++};
+++
+++&pcie1 {
+++	status = "okay";
+++
+++	bridge@0,0 {
+++		reg = <0x00000000 0 0 0 0>;
+++		#address-cells = <3>;
+++		#size-cells = <2>;
+++		ranges;
+++
+++		wifi@1,0 {
+++			compatible = "qcom,ath10k";
+++			status = "okay";
+++			reg = <0x10000 0 0 0 0>;
+++
+++			nvmem-cells = <&precal_art_5000>;
+++			nvmem-cell-names = "pre-calibration";
+++		};
+++	};
+++};
+++
+++&nand {
+++	status = "okay";
+++
+++	nand@0 {
+++		compatible = "qcom,nandcs";
+++
+++		reg = <0>;
+++
+++		nand-ecc-strength = <4>;
+++		nand-bus-width = <8>;
+++		nand-ecc-step-size = <512>;
+++
+++		partitions {
+++			compatible = "fixed-partitions";
+++			#address-cells = <1>;
+++			#size-cells = <1>;
+++
+++			aos0@0 {
+++				label = "aos0";
+++				reg = <0x0 0x2000000>;
+++			};
+++
+++			aos1@2000000 {
+++				label = "aos1";
+++				reg = <0x2000000 0x2000000>;
+++			};
+++
+++			ubifs@4000000 {
+++				label = "ubifs";
+++				reg = <0x4000000 0x4000000>;
+++			};
+++		};
+++	};
+++};
+++
+++&mdio0 {
+++	status = "okay";
+++
+++	pinctrl-0 = <&mdio0_pins>;
+++	pinctrl-names = "default";
+++
+++	phy0: ethernet-phy@0 {
+++		reg = <0>;
+++	};
+++
+++	phy1: ethernet-phy@1 {
+++		reg = <1>;
+++	};
+++};
+++
+++&gmac2 {
+++	status = "okay";
+++
+++	qcom,id = <2>;
+++	mdiobus = <&mdio0>;
+++
+++	phy-mode = "sgmii";
+++	phy-handle = <&phy0>;
+++
+++	nvmem-cells = <&macaddr_lan 0>;
+++	nvmem-cell-names = "mac-address";
+++};
+++
+++&gmac3 {
+++	status = "okay";
+++
+++	qcom,id = <3>;
+++	mdiobus = <&mdio0>;
+++
+++	phy-mode = "sgmii";
+++	phy-handle = <&phy1>;
+++
+++	nvmem-cells = <&macaddr_lan 1>;
+++	nvmem-cell-names = "mac-address";
+++};
+++
+++&adm_dma {
+++	status = "okay";
+++};
+++
+++/* USB Port 0 is connected to the onboard BLE SoC.
+++ * The stock FW on that doesn't implement USB, so to prevent errors from
+++ * being logged when the host fails to initialize it, it's disabled by
+++ * default here. */
+++&hs_phy_0 {
+++	status = "disabled";
+++};
+++
+++&ss_phy_0 {
+++	status = "disabled";
+++};
+++
+++&usb3_0 {
+++	status = "disabled";
+++};
+++
+++&hs_phy_1 {
+++	status = "okay";
+++};
+++
+++&ss_phy_1 {
+++	status = "okay";
+++};
+++
+++&usb3_1 {
+++	status = "okay";
+++};
++diff --git a/target/linux/ipq806x/image/generic.mk b/target/linux/ipq806x/image/generic.mk
++index 112793d5fd..b8d7a187a9 100644
++--- a/target/linux/ipq806x/image/generic.mk
+++++ b/target/linux/ipq806x/image/generic.mk
++@@ -47,6 +47,18 @@ define Build/linksys-addfwhdr
++        	;mv "$@.new" "$@"
++ endef
++ 
+++define Build/apboot-addfwhdr
+++	$(SCRIPT_DIR)/aruba-header.py \
+++		$@ $@.new \
+++		"$(call toupper,$(LINUX_KARCH)) $(VERSION_DIST) Linux-$(LINUX_VERSION), $(VERSION_NUMBER) $(VERSION_CODE)"\
+++		"$(VERSION_NUMBER)" \
+++		"$(VERSION_DIST)" \
+++		os \
+++		"$(word 1,$(1))"
+++
+++	mv "$@.new" "$@"
+++endef
+++
++ define Device/DniImage
++ 	KERNEL_SUFFIX := -uImage
++ 	KERNEL = kernel-bin | append-dtb | uImage none
++@@ -101,6 +113,25 @@ define Device/arris_tr4400-v2
++ endef
++ TARGET_DEVICES += arris_tr4400-v2
++ 
+++define Device/aruba_ap-32x
+++	$(call Device/LegacyImage)
+++	DEVICE_VENDOR := Aruba
+++	DEVICE_MODEL := AP-325
+++	DEVICE_ALT0_VENDOR := Aruba
+++	DEVICE_ALT0_MODEL := AP-324
+++	DEVICE_ALT1_VENDOR := Siemens
+++	DEVICE_ALT1_MODEL := Scalance W1750D
+++	SOC := qcom-ipq8068
+++	PAGESIZE := 2048
+++	BLOCKSIZE := 128k
+++	KERNEL_SUFFIX := .ari
+++	KERNEL = kernel-bin | append-dtb | uImage none | apboot-addfwhdr Octomore
+++	KERNEL_LOADADDR = 0x41508000
+++	KERNEL_SIZE := 30720k
+++	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-i2c-gpio kmod-tpm-i2c-atmel
+++endef
+++TARGET_DEVICES += aruba_ap-32x
+++
++ define Device/askey_rt4230w-rev6
++ 	$(call Device/LegacyImage)
++ 	$(Device/dsa-migration)
++-- 
++2.43.0
++
+diff --git a/patches/openwrt/0018-ipq806x-add-apboot-package-for-AP-32x.patch b/patches/openwrt/0018-ipq806x-add-apboot-package-for-AP-32x.patch
+new file mode 100644
+index 00000000..d70676b1
+--- /dev/null
++++ b/patches/openwrt/0018-ipq806x-add-apboot-package-for-AP-32x.patch
+@@ -0,0 +1,119 @@
++From e0e8ff48982fdb0ab4fbd8c68d875c3c231b2f22 Mon Sep 17 00:00:00 2001
++From: Lukas Stockner <lukas@lukasstockner.de>
++Date: Fri, 12 Jun 2026 17:05:20 +0200
++Subject: [PATCH 5/5] ipq806x: add apboot package for AP-32x
++
++This is unfortunately needed to disable the signature verification
++in the stock bootloader.
++
++Co-authored-by: Paul Spooren <mail@aparcar.org>
++Signed-off-by: Lukas Stockner <lukas@lukasstockner.de>
++---
++ package/boot/apboot-aruba-ipq806x/Makefile | 77 ++++++++++++++++++++++
++ target/linux/ipq806x/image/generic.mk      |  6 +-
++ 2 files changed, 82 insertions(+), 1 deletion(-)
++ create mode 100644 package/boot/apboot-aruba-ipq806x/Makefile
++
++diff --git a/package/boot/apboot-aruba-ipq806x/Makefile b/package/boot/apboot-aruba-ipq806x/Makefile
++new file mode 100644
++index 0000000000..141b359b23
++--- /dev/null
+++++ b/package/boot/apboot-aruba-ipq806x/Makefile
++@@ -0,0 +1,77 @@
+++#
+++# Copyright (C) 2026 OpenWrt.org
+++#
+++# This is free software, licensed under the GNU General Public License v2.
+++# See /LICENSE for more information.
+++#
+++
+++include $(TOPDIR)/rules.mk
+++
+++PKG_NAME:=apboot-aruba-ipq806x
+++PKG_RELEASE:=1
+++
+++PKG_SOURCE_PROTO:=git
+++PKG_SOURCE_URL:=https://github.com/lukasstockner/ap325-apboot-openwrt.git
+++PKG_MIRROR_HASH:=ef91bc1539d50c19c35ae5d38eab1a4944692d3f651952f58800ea1f7ffd4878
+++PKG_SOURCE_DATE:=2026-06-12
+++PKG_SOURCE_VERSION:=d36bb7270a8a8a5c5988ff778e55de12e0c40745
+++
+++PKG_LICENSE:=GPL-2.0-or-later
+++PKG_LICENSE_FILES:=COPYING
+++PKG_MAINTAINER:=Lukas Stockner <lukas@lukasstockner.de>
+++
+++# Legacy U-Boot tree, not Kbuild-parallel safe.
+++PKG_BUILD_PARALLEL:=0
+++PKG_FLAGS:=nonshared
+++
+++include $(INCLUDE_DIR)/package.mk
+++
+++# Aruba/QCA board name in the APBoot tree (Makefile.releng target):
+++#   octomore -> AP-324 / AP-325 (and Siemens Scalance W1750D)
+++APBOOT_BOARD:=octomore
+++
+++# Stamped into the version banner; the upstream Dockerfile uses the short hash.
+++APBOOT_LABELID:=$(call version_abbrev,$(PKG_SOURCE_VERSION))
+++
+++define Package/apboot-aruba-ipq806x
+++  SECTION:=boot
+++  CATEGORY:=Boot Loaders
+++  DEPENDS:=@TARGET_ipq806x
+++  TITLE:=Patched Aruba APBoot for AP-32x
+++  URL:=https://github.com/lukasstockner/ap325-apboot-openwrt
+++endef
+++
+++define Package/apboot-aruba-ipq806x/description
+++  Patched build of the Aruba APBoot bootloader (a vendor fork of U-Boot) for
+++  the Aruba AP-324 / AP-325 access points (board "octomore"). The factory
+++  bootloader enforces RSA signatures on the firmware; this build removes the
+++  signature check and switches the console to 115200 baud so that OpenWrt can
+++  be booted. The resulting "u-boot.mbn" is meant to be flashed to the APPSBL
+++  SPI-flash partition via the serial console.
+++endef
+++
+++# APBoot is a freestanding U-Boot, so build it with OpenWrt's target
+++# cross-toolchain instead of the bare-metal arm-none-eabi- default. The legacy
+++# Makefile honours an externally supplied CROSS_COMPILE.
+++define Build/Compile
+++	+$(MAKE) -C $(PKG_BUILD_DIR) -f Makefile.releng $(APBOOT_BOARD) \
+++		SHELL=/bin/bash \
+++		CROSS_COMPILE=$(TARGET_CROSS) \
+++		HOSTCC="$(HOSTCC)" \
+++		LABELID=$(APBOOT_LABELID) \
+++		ARUBA_MAKE_VERBOSE=1
+++endef
+++
+++# The bootloader is flashed by hand and is not part of the root filesystem.
+++# Stage the image so the ipq806x image build can emit it as a device artifact.
+++define Build/InstallDev
+++	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+++	$(INSTALL_DATA) $(PKG_BUILD_DIR)/u-boot.mbn \
+++		$(STAGING_DIR_IMAGE)/aruba_ap-32x-apboot.mbn
+++endef
+++
+++define Package/apboot-aruba-ipq806x/install
+++	:
+++endef
+++
+++$(eval $(call BuildPackage,apboot-aruba-ipq806x))
++diff --git a/target/linux/ipq806x/image/generic.mk b/target/linux/ipq806x/image/generic.mk
++index b8d7a187a9..7b19c07b7b 100644
++--- a/target/linux/ipq806x/image/generic.mk
+++++ b/target/linux/ipq806x/image/generic.mk
++@@ -128,7 +128,11 @@ define Device/aruba_ap-32x
++ 	KERNEL = kernel-bin | append-dtb | uImage none | apboot-addfwhdr Octomore
++ 	KERNEL_LOADADDR = 0x41508000
++ 	KERNEL_SIZE := 30720k
++-	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-i2c-gpio kmod-tpm-i2c-atmel
+++	UBOOT_PATH := $$(STAGING_DIR_IMAGE)/aruba_ap-32x-apboot.mbn
+++	ARTIFACTS := apboot.mbn
+++	ARTIFACT/apboot.mbn := append-uboot
+++	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-i2c-gpio kmod-tpm-i2c-atmel \
+++		apboot-aruba-ipq806x
++ endef
++ TARGET_DEVICES += aruba_ap-32x
++ 
++-- 
++2.43.0
++
+-- 
+2.43.0
+

--- a/patches/0002-targets-add-support-for-aruba-ap32x.patch
+++ b/patches/0002-targets-add-support-for-aruba-ap32x.patch
@@ -1,0 +1,29 @@
+From 3bdfeccde636a74422a7760d3510653dae0c69eb Mon Sep 17 00:00:00 2001
+From: Florian Maurer <f.maurer@outlook.de>
+Date: Thu, 18 Jun 2026 10:00:22 +0200
+Subject: [PATCH 2/2] targets: add support for aruba-ap32x
+
+---
+ targets/ipq806x-generic | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/targets/ipq806x-generic b/targets/ipq806x-generic
+index 641d89ce..1ac0fc77 100644
+--- a/targets/ipq806x-generic
++++ b/targets/ipq806x-generic
+@@ -11,6 +11,12 @@ local QCA9984_PACKAGES = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca
+ -- QCA9980 / QCA9990
+ --
+ 
++-- Aruba
++
++device('aruba-ap-32x', 'aruba_ap-32x', {
++	packages = QCA9980_PACKAGES, factory = false,
++})
++
+ -- Extreme Networks
+ 
+ device('extreme-networks-ap3935', 'extreme_ap3935', {
+-- 
+2.43.0
+


### PR DESCRIPTION
To provide experimental images for this new device, we should integrate this into the experimental branch.