### PR TITLE
Bump gluon main to latest main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 124b0acd23952dea57fc1ec63020ff137ddd0097 # gluon main (2025-10-06)
+GLUON_GIT_REF := 423258a7c85875fae0653b659033463963c8eb91 # gluon main (2025-11-04)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
this supersedes #604 as this bump should include the upstream reboot fix

https://github.com/freifunk-gluon/gluon/compare/124b0acd23952dea57fc1ec63020ff137ddd0097..423258a7c85875fae0653b659033463963c8eb91

https://github.com/openwrt/openwrt/compare/v24.10.4...4ead11296a30276d5aafb0a326bad18a61fd74b5