### PR TITLE
Test futro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 423258a7c85875fae0653b659033463963c8eb91 # gluon main (2025-11-04)
+GLUON_GIT_REF := 0af1e351787aa2028bd77ed621ff4eb8f5da5e01 # gluon main (2025-11-20)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key

--- a/patches/x86-fix-eth-driver-order-3612.patch
+++ b/patches/x86-fix-eth-driver-order-3612.patch
@@ -1,0 +1,136 @@
+From 8d444052b0e4c0a04a2dba0f0e59b45cd3d04e66 Mon Sep 17 00:00:00 2001
+From: Nora Matthias Schiffer <neocturne@universe-factory.net>
+Date: Fri, 14 Nov 2025 21:26:23 +0100
+Subject: [PATCH] gluon-core: add migration for Ethernet driver load order
+ change
+
+To account for the change module load order between OpenWrt 23.05 and
+24.10 for some Ethernet drivers, resulting in eth0 and eth1 (and
+therefore LAN and WAN) interfaces to switch, also switch the LAN and WAN
+roles to keep the correct roles on each physical port.
+
+For VLAN interfaces, eth0 and eth1 are switched in the interface name
+instead.
+---
+ .../gluon/upgrade/019-migrate-interface-order | 112 ++++++++++++++++++
+ 1 file changed, 112 insertions(+)
+ create mode 100755 package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order
+
+diff --git a/package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order b/package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order
+new file mode 100755
+index 0000000000..01d25ec32e
+--- /dev/null
++++ b/package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order
+@@ -0,0 +1,112 @@
++#!/usr/bin/lua
++
++local platform = require 'gluon.platform'
++local sysconfig = require 'gluon.sysconfig'
++
++local libgen = require 'posix.libgen'
++local unistd = require 'posix.unistd'
++local uci = require('simple-uci').cursor()
++
++if not platform.match('x86') then
++	return
++end
++
++if sysconfig.migrated_interface_order then
++	return
++end
++sysconfig.migrated_interface_order = ''
++
++local lan_roles = uci:get_list('gluon', 'iface_lan', 'role')
++local wan_roles = uci:get_list('gluon', 'iface_wan', 'role')
++
++if #lan_roles == 0 and #wan_roles == 0 then
++	return
++end
++
++local lan_ifname = sysconfig.lan_ifname
++local wan_ifname = sysconfig.wan_ifname
++
++local function is_default(ifname)
++	return ifname == 'eth0' or ifname == 'eth1'
++end
++
++if not is_default(lan_ifname) or not is_default(wan_ifname) then
++	return
++end
++
++-- v2023.2.x load order (/proc/modules) - Ethernet drivers only
++-- (x86-64; should be accurate enough for x64-generic as well)
++-- Does not account for site-specific driver additions
++local prev_load_order = {
++	'tg3',
++	'igb',
++	'fsl_mph_dr_of',
++	'ena',
++	'natsemi',
++	'amd_xgbe',
++	'e1000',
++	'ixgbe',
++	'3c59x',
++	'8139cp',
++	'8139too',
++	'8390',
++	'bnx2',
++	'e100',
++	'e1000e',
++	'forcedeth',
++	'igc',
++	'ne2k_pci',
++	'pcnet32',
++	'r8169',
++	'sis900',
++	'sky2',
++	'tulip',
++	'via_rhine',
++	'via_velocity',
++}
++
++local prev_load_index = {}
++for index, driver in ipairs(prev_load_order) do
++	prev_load_index[driver] = index
++end
++
++local function get_prev_driver_index(ifname)
++	local path = '/sys/class/net/' .. ifname .. '/device/driver'
++	local driver_path = unistd.readlink(path)
++	if not driver_path then
++		return 0
++	end
++	local driver = libgen.basename(driver_path)
++	local order = prev_load_index[driver]
++	if not order then
++		return 0
++	end
++	return order
++end
++
++-- If the drivers would be loaded in the inverse order in previous Gluon
++-- versions (eth1 had a smaller load index than eth0), switch the roles
++if get_prev_driver_index('eth0') <= get_prev_driver_index('eth1') then
++	return
++end
++
++print('Switching LAN and WAN roles after module load order change')
++
++uci:set('gluon', 'iface_lan', 'role', wan_roles)
++uci:set('gluon', 'iface_wan', 'role', lan_roles)
++
++-- Migrate VLAN interfaces
++uci:foreach('gluon', 'interface', function(interface)
++	local base, suffix = string.match(interface.name, '^(eth[01])(%..*)$')
++	if base == 'eth0' then
++		base = 'eth1'
++	elseif base == 'eth1' then
++		base = 'eth0'
++	else
++		return
++	end
++
++	uci:set('gluon', interface['.name'], 'name', base .. suffix)
++end)
++
++uci:save('gluon')


### PR DESCRIPTION
This adds a patch from https://github.com/freifunk-gluon/gluon/pull/3612 to test this upgrade with futros.
This should make sure, that the port ordering is consistent.