### PR TITLE
bump gluon main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := 423258a7c85875fae0653b659033463963c8eb91 # gluon main (2025-11-04)
+GLUON_GIT_REF := 8f38662f44f5df69357ced93f166000716f018b3 # gluon main (2025-11-26)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
Includes the following updates:

gluon-core: limit size of wireless buffers
gluon-wan-dnsmasq: work around missing capabilities for libpacketmark + minor cleanup
gluon-core: add migration for Ethernet driver load order change
gluon-setup-mode: fix non-interactive dropbear sessions
modules: update openwrt base
mediatek-filogic: add cudy-wr3000e
ipq40xx-generic: add support for Netgear RBR50v1/RBS50v1
mediatek-mt7622: add support for netgear wax206
mediatek-filogic: Add support for Xiaomi AX3000T ubootmod