### PR TITLE
use .scmversion file to set site version correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ info:
 	@echo
 
 build: gluon-prepare output-clean
+	git --git-dir=.git describe --tags --always --abbrev=7 --dirty=+ 2>/dev/null > .scmversion
 ifeq ($(origin GLUON_DEVICES), undefined)
 	for target in ${GLUON_TARGETS}; do \
 		echo ""Building target $$target""; \
@@ -79,10 +80,12 @@ gluon-patch:
 
 gluon-clean:
 	rm -rf ${GLUON_BUILD_DIR}
+	rm -f .scmversion
 
 output-clean:
 	mkdir -p output/
 	rm -rf output/*
+	rm -f .scmversion
 
 clean: gluon-clean output-clean
 


### PR DESCRIPTION
As suggested by @T0biii we need to overwrite the site version due to the annotated tag requirement in the new release: https://github.com/freifunk-gluon/gluon/pull/3632

EDIT: This needs testing in particular on the v2023.1.x branch, as this also had the annotated-tag requirement similar to the new v2025.1.x