### PR TITLE
site: pin opkg to latest 22.03.7 release

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -5,6 +5,7 @@
   default_domain = 'ffmuc_welt',
 
   opkg = {
+    openwrt = 'http://downloads.openwrt.org/releases/22.03.7/packages/%A',
     extra = {
       gluon = 'http://firmware.ffmuc.net/%GR/packages/gluon-%GS-%GR/%S',
     },


### PR DESCRIPTION
There are no snapshot packages for 22.03 anymore.

Should be tested.