### PR TITLE
CI: use ubuntu-slim as runner image

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # Don't run on closed unmerged pull requests
     if: github.event.pull_request.merged
     steps:

--- a/.github/workflows/bump-modules.yml
+++ b/.github/workflows/bump-modules.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-Modules:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
       - name: Clone Firmware
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,7 +16,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   shellcheck:
     name: runner / shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Clone Firmware
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/update-targets.yml
+++ b/.github/workflows/update-targets.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   update-Modules:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Clone Firmware
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Lets use ubuntu-slim for not heavy tasks 
https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/