### PR TITLE
bump gluon-v2025.1.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2025.1
+GLUON_GIT_REF := 9a0b5b21a5e91329f9ab416ad8bc788379aaa2a3 #v2025.1.x (2026.02.25)
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
https://github.com/freifunk-gluon/gluon/compare/v2025.1...9a0b5b21a5e91329f9ab416ad8bc788379aaa2a3
```
batman-adv: avoid double-rtnl_lock ELP metric worker
mediatek-filogic: add support for Cudy RE3000 v1
ath79-generic: re add support for ubiquiti-rocket-m-xm
mediatek-filogic: add support for Cudy M3000 v1
mediatek-filogic: add support for Cudy WR3000S
ramips-mt7621: add support for Totolink X5000R
mediatek-mt7622: add support for Ubiquiti UniFi 6 LR v3
ramips-mt7621: Add Cudy WR3000h (v1.0) 2.5G WAN model
ramips-mt7621: add support for Cudy AP1300 Outdoor v1
mediatek-filogic: add device Mercusys MR90X v1
```

closes #776