### PR TITLE
Batman V support for node-whisperer (incl. node-monitor)

### DIFF
--- a/patches/0001-use-Batman-V-node-whisperer.patch
+++ b/patches/0001-use-Batman-V-node-whisperer.patch
@@ -1,0 +1,47 @@
+From b1be1e4386423dabd9481fe7f9a06133fc185e2e Mon Sep 17 00:00:00 2001
+From: Grische <2787581+grische@users.noreply.github.com>
+Date: Mon, 17 Sep 2025 17:33:01 +0200
+Subject: [PATCH] use ffmuc node-whisperer with Batman V support
+
+---
+ .../0001-use-Batman-V-node-whisperer.patch    | 29 ++++++
+ create mode 100644 patches/packages/community/0001-use-Batman-V-node-whisperer.patch
+
+diff --git a/patches/packages/community/0001-use-Batman-V-node-whisperer.patch b/patches/packages/community/0001-use-Batman-V-node-whisperer.patch
+new file mode 100644
+index 00000000..1e8127bc
+--- /dev/null
++++ b/patches/packages/community/0001-use-Batman-V-node-whisperer.patch
+@@ -0,0 +1,29 @@
++From 4c7a5de449181882a730f5d8328de5d3ad1f6d5d Mon Sep 17 00:00:00 2001
++From: Grische <2787581+grische@users.noreply.github.com>
++Date: Fri, 27 Jun 2025 17:06:58 +0200
++Subject: [PATCH] use ffmuc node-whisperer with Batman V support
++
++---
++ ffda-node-whisperer/Makefile | 6 +++---
++ 1 file changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/ffda-node-whisperer/Makefile b/ffda-node-whisperer/Makefile
++index 5b01edd..1a81202 100644
++--- a/ffda-node-whisperer/Makefile
+++++ b/ffda-node-whisperer/Makefile
++@@ -4,9 +4,9 @@ PKG_NAME:=ffda-node-whisperer
++ PKG_RELEASE:=1
++ 
++ PKG_SOURCE_PROTO:=git
++-PKG_SOURCE_URL=https://github.com/blocktrron/node-whisperer.git
++-PKG_SOURCE_DATE:=2024-11-09
++-PKG_SOURCE_VERSION:=8f1e5560ce2e9319083004af4b6bfd87e4d246b3
+++PKG_SOURCE_URL=https://github.com/freifunkMUC/node-whisperer.git
+++PKG_SOURCE_DATE:=2026-05-14
+++PKG_SOURCE_VERSION:=f42f9d332fe3456ce3baf369672de6eb5ae71c90
++ 
++ PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
++ PKG_LICENSE:=GPL-2.0-or-later
++-- 
++2.43.0
++
+-- 
+2.43.0
+

--- a/patches/0002-deploy-node-monitor.patch
+++ b/patches/0002-deploy-node-monitor.patch
@@ -1,0 +1,43 @@
+From 788432a058e6d10361012b90a090e6d66f373cb9 Mon Sep 17 00:00:00 2001
+From: Grische <2787581+grische@users.noreply.github.com>
+Date: Fri, 10 Apr 2026 17:15:14 +0200
+Subject: [PATCH] also deploy node-monitor
+
+---
+ .../community/0002-deploy-node-monitor.patch  | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+ create mode 100644 patches/packages/community/0002-deploy-node-monitor.patch
+
+diff --git a/patches/packages/community/0002-deploy-node-monitor.patch b/patches/packages/community/0002-deploy-node-monitor.patch
+new file mode 100644
+index 00000000..587ed057
+--- /dev/null
++++ b/patches/packages/community/0002-deploy-node-monitor.patch
+@@ -0,0 +1,24 @@
++From ea11ee2af9c354d705a607fc56376f286f801097 Mon Sep 17 00:00:00 2001
++From: Grische <2787581+grische@users.noreply.github.com>
++Date: Fri, 10 Apr 2026 17:14:07 +0200
++Subject: [PATCH] ffda-node-whisperer: also deploy node-monitor
++
++---
++ ffda-node-whisperer/Makefile | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/ffda-node-whisperer/Makefile b/ffda-node-whisperer/Makefile
++index 75d4bfa..d089cdd 100644
++--- a/ffda-node-whisperer/Makefile
+++++ b/ffda-node-whisperer/Makefile
++@@ -36,6 +36,7 @@ endef
++ define Package/ffda-node-whisperer/install
++ 	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config $(1)/lib/gluon/upgrade
++ 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/node-whisperer $(1)/usr/bin
+++	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/node-monitor $(1)/usr/bin
++ 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/node-whisperer/files/node-whisperer.init $(1)/etc/init.d/node-whisperer
++ 	$(CP) $(PKG_BUILD_DIR)/openwrt/node-whisperer/files/node-whisperer.uci $(1)/etc/config/node-whisperer
++ 	$(INSTALL_BIN) ./files/node-whisperer.upgrade.lua $(1)/lib/gluon/upgrade/150-node-whisperer
++-- 
++2.43.0
++
+-- 
+2.43.0
+

--- a/site.conf
+++ b/site.conf
@@ -167,7 +167,7 @@
       'domain',
       'system_load',
       'firmware_version',
-      -- 'batman_adv', Batman V is not yet supported, see https://github.com/freifunk-darmstadt/node-whisperer/issues/2
+      'batman_adv',
     },
   },
 }


### PR DESCRIPTION
This is a patch series for a couple of improvements to node-whisperer, incl. adding node-monitor on devices for scanning other node-whisper results.

The full diff is:
https://github.com/freifunkMUC/node-whisperer/compare/8f1e5560ce2e9319083004af4b6bfd87e4d246b3...f42f9d332fe3456ce3baf369672de6eb5ae71c90