### PR TITLE
patches: add support for NanoPi R2S Plus

### DIFF
--- a/patches/0001-patches-add-OpenWrt-support-for-FriendlyElec-NanoPi-.patch
+++ b/patches/0001-patches-add-OpenWrt-support-for-FriendlyElec-NanoPi-.patch
@@ -1,0 +1,394 @@
+From 9fe42158777eccdd16d9aab25690b9ca091adadc Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Wed, 17 Jun 2026 14:27:21 +0200
+Subject: [PATCH 1/2] patches: add OpenWrt support for FriendlyElec NanoPi R2S
+ Plus
+
+Add the U-Boot and rockchip image/board.d patches required to build
+OpenWrt for the NanoPi R2S Plus, a NanoPi R2S variant with on-board
+eMMC. MAC addresses are derived from the eMMC CID and stay stable
+across microSD/eMMC boots.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ ...rockchip-add-NanoPi-R2S-Plus-support.patch | 267 ++++++++++++++++++
+ ...port-for-FriendlyARM-NanoPi-R2S-Plus.patch |  93 ++++++
+ 2 files changed, 360 insertions(+)
+ create mode 100644 patches/openwrt/0014-uboot-rockchip-add-NanoPi-R2S-Plus-support.patch
+ create mode 100644 patches/openwrt/0015-rockchip-Add-support-for-FriendlyARM-NanoPi-R2S-Plus.patch
+
+diff --git a/patches/openwrt/0014-uboot-rockchip-add-NanoPi-R2S-Plus-support.patch b/patches/openwrt/0014-uboot-rockchip-add-NanoPi-R2S-Plus-support.patch
+new file mode 100644
+index 00000000..92339563
+--- /dev/null
++++ b/patches/openwrt/0014-uboot-rockchip-add-NanoPi-R2S-Plus-support.patch
+@@ -0,0 +1,267 @@
++From 515a3f914aa732299f3d43f92b21f107f69b59da Mon Sep 17 00:00:00 2001
++From: Grische <github@grische.xyz>
++Date: Wed, 17 Jun 2026 14:09:18 +0200
++Subject: [PATCH 1/2] uboot-rockchip: add NanoPi R2S Plus support
++
++Backport NanoPi R2S Plus board support from U-Boot mainline, which first
++shipped in v2025.01:
++
++  d6a55cc9e7e arm64: dts: rockchip: Add DTS for FriendlyARM NanoPi R2S Plus
++  3133b7c6451 board: rockchip: Add FriendlyElec NanoPi R2S Plus
++
++The board DTS includes rk3328-nanopi-r2s.dts directly, matching the
++device tree layout present in U-Boot 2024.10, and enables the on-board
++eMMC so the SPL can load U-Boot from it.
++
++Signed-off-by: Grische <github@grische.xyz>
++Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
++---
++ package/boot/uboot-rockchip/Makefile          |   8 +
++ ...-DTS-for-FriendlyARM-NanoPi-R2S-Plus.patch |  59 ++++++++
++ ...hip-Add-FriendlyElec-NanoPi-R2S-Plus.patch | 142 ++++++++++++++++++
++ 3 files changed, 209 insertions(+)
++ create mode 100644 package/boot/uboot-rockchip/patches/107-1-arm64-dts-rockchip-Add-DTS-for-FriendlyARM-NanoPi-R2S-Plus.patch
++ create mode 100644 package/boot/uboot-rockchip/patches/107-2-board-rockchip-Add-FriendlyElec-NanoPi-R2S-Plus.patch
++
++diff --git a/package/boot/uboot-rockchip/Makefile b/package/boot/uboot-rockchip/Makefile
++index 74cacde33e..1e2853cdf5 100644
++--- a/package/boot/uboot-rockchip/Makefile
+++++ b/package/boot/uboot-rockchip/Makefile
++@@ -71,6 +71,13 @@ define U-Boot/nanopi-r2s-rk3328
++     friendlyarm_nanopi-r2s
++ endef
++ 
+++define U-Boot/nanopi-r2s-plus-rk3328
+++  $(U-Boot/rk3328/Default)
+++  NAME:=NanoPi R2S Plus
+++  BUILD_DEVICES:= \
+++    friendlyarm_nanopi-r2s-plus
+++endef
+++
++ define U-Boot/orangepi-r1-plus-rk3328
++   $(U-Boot/rk3328/Default)
++   NAME:=Orange Pi R1 Plus
++@@ -336,6 +343,7 @@ UBOOT_TARGETS := \
++   nanopi-r2c-rk3328 \
++   nanopi-r2c-plus-rk3328 \
++   nanopi-r2s-rk3328 \
+++  nanopi-r2s-plus-rk3328 \
++   orangepi-r1-plus-rk3328 \
++   orangepi-r1-plus-lts-rk3328 \
++   roc-cc-rk3328 \
++diff --git a/package/boot/uboot-rockchip/patches/107-1-arm64-dts-rockchip-Add-DTS-for-FriendlyARM-NanoPi-R2S-Plus.patch b/package/boot/uboot-rockchip/patches/107-1-arm64-dts-rockchip-Add-DTS-for-FriendlyARM-NanoPi-R2S-Plus.patch
++new file mode 100644
++index 0000000000..09e4c35226
++--- /dev/null
+++++ b/package/boot/uboot-rockchip/patches/107-1-arm64-dts-rockchip-Add-DTS-for-FriendlyARM-NanoPi-R2S-Plus.patch
++@@ -0,0 +1,59 @@
+++From d6a55cc9e7e7d44b4b357818a9690e05af5d87e2 Mon Sep 17 00:00:00 2001
+++From: Sergey Bostandzhyan <jin@mediatomb.cc>
+++Date: Fri, 1 Nov 2024 22:21:29 +0000
+++Subject: [PATCH 1/2] arm64: dts: rockchip: Add DTS for FriendlyARM NanoPi R2S
+++ Plus
+++
+++The R2S Plus is basically an R2S with additional eMMC.
+++
+++The eMMC configuration for the DTS has been extracted and copied from
+++rk3328-nanopi-r2.dts, v2017.09 branch from the friendlyarm/uboot-rockchip
+++repository.
+++
+++Signed-off-by: Sergey Bostandzhyan <jin@mediatomb.cc>
+++Link: https://lore.kernel.org/r/20240814170048.23816-2-jin@mediatomb.cc
+++Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+++[ upstream commit: b8c02878292200ebb5b4a8cfc9dbf227327908bd ]
+++(cherry picked from commit c9bf98827964441f4dd16faa45bd4046f472e693)
+++Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+++Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+++---
+++ .../src/arm64/rockchip/rk3328-nanopi-r2s-plus.dts  | 32 ++++++++++++++++++++++
+++ 1 file changed, 32 insertions(+)
+++ create mode 100644 dts/upstream/src/arm64/rockchip/rk3328-nanopi-r2s-plus.dts
+++
+++--- /dev/null
++++++ b/dts/upstream/src/arm64/rockchip/rk3328-nanopi-r2s-plus.dts
+++@@ -0,0 +1,32 @@
++++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++++/*
++++ * (C) Copyright 2018 FriendlyElec Computer Tech. Co., Ltd.
++++ * (http://www.friendlyarm.com)
++++ *
++++ * (C) Copyright 2016 Rockchip Electronics Co., Ltd
++++ */
++++
++++/dts-v1/;
++++#include "rk3328-nanopi-r2s.dts"
++++
++++/ {
++++	compatible = "friendlyarm,nanopi-r2s-plus", "rockchip,rk3328";
++++	model = "FriendlyElec NanoPi R2S Plus";
++++
++++	aliases {
++++		mmc1 = &emmc;
++++	};
++++};
++++
++++&emmc {
++++	bus-width = <8>;
++++	cap-mmc-highspeed;
++++	disable-wp;
++++	mmc-hs200-1_8v;
++++	non-removable;
++++	num-slots = <1>;
++++	pinctrl-names = "default";
++++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++++	supports-emmc;
++++	status = "okay";
++++};
++diff --git a/package/boot/uboot-rockchip/patches/107-2-board-rockchip-Add-FriendlyElec-NanoPi-R2S-Plus.patch b/package/boot/uboot-rockchip/patches/107-2-board-rockchip-Add-FriendlyElec-NanoPi-R2S-Plus.patch
++new file mode 100644
++index 0000000000..c9b3e7e604
++--- /dev/null
+++++ b/package/boot/uboot-rockchip/patches/107-2-board-rockchip-Add-FriendlyElec-NanoPi-R2S-Plus.patch
++@@ -0,0 +1,142 @@
+++From 3133b7c645157846590f6fc16e26f54d70f5e1d6 Mon Sep 17 00:00:00 2001
+++From: Jonas Karlman <jonas@kwiboo.se>
+++Date: Fri, 1 Nov 2024 22:21:30 +0000
+++Subject: [PATCH 2/2] board: rockchip: Add FriendlyElec NanoPi R2S Plus
+++
+++The FriendlyElec NanoPi R2S Plus is a single-board computer based on
+++Rockchip RK3328 SoC. It features e.g. 1 GB DDR4 RAM, 32 GB eMMC,
+++SD-card, 2x GbE LAN, optional M.2 SDIO Wi-Fi and 2x USB 2.0 host.
+++
+++Features tested on a NanoPi R2S Plus 2309:
+++- SD-card boot
+++- eMMC boot
+++- Ethernet
+++- USB gadget
+++- USB host
+++
+++Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+++Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+++---
+++ arch/arm/dts/rk3328-nanopi-r2s-plus-u-boot.dtsi |   3 +
+++ configs/nanopi-r2s-plus-rk3328_defconfig        | 108 ++++++++++++++++++++++++
+++ 2 files changed, 111 insertions(+)
+++ create mode 100644 arch/arm/dts/rk3328-nanopi-r2s-plus-u-boot.dtsi
+++ create mode 100644 configs/nanopi-r2s-plus-rk3328_defconfig
+++
+++--- /dev/null
++++++ b/arch/arm/dts/rk3328-nanopi-r2s-plus-u-boot.dtsi
+++@@ -0,0 +1,3 @@
++++// SPDX-License-Identifier: GPL-2.0-or-later
++++
++++#include "rk3328-nanopi-r2s-u-boot.dtsi"
+++--- /dev/null
++++++ b/configs/nanopi-r2s-plus-rk3328_defconfig
+++@@ -0,0 +1,108 @@
++++CONFIG_ARM=y
++++CONFIG_SKIP_LOWLEVEL_INIT=y
++++CONFIG_COUNTER_FREQUENCY=24000000
++++CONFIG_ARCH_ROCKCHIP=y
++++CONFIG_SPL_GPIO=y
++++CONFIG_NR_DRAM_BANKS=1
++++CONFIG_SF_DEFAULT_SPEED=20000000
++++CONFIG_ENV_OFFSET=0x3F8000
++++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3328-nanopi-r2s-plus"
++++CONFIG_DM_RESET=y
++++CONFIG_ROCKCHIP_RK3328=y
++++CONFIG_SYS_LOAD_ADDR=0x800800
++++CONFIG_DEBUG_UART_BASE=0xFF130000
++++CONFIG_DEBUG_UART_CLOCK=24000000
++++CONFIG_DEBUG_UART=y
++++# CONFIG_ANDROID_BOOT_IMAGE is not set
++++CONFIG_FIT=y
++++CONFIG_FIT_VERBOSE=y
++++CONFIG_SPL_FIT_SIGNATURE=y
++++CONFIG_SPL_LOAD_FIT=y
++++CONFIG_LEGACY_IMAGE_FORMAT=y
++++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-nanopi-r2s-plus.dtb"
++++# CONFIG_DISPLAY_CPUINFO is not set
++++CONFIG_DISPLAY_BOARDINFO_LATE=y
++++CONFIG_SPL_MAX_SIZE=0x40000
++++CONFIG_SPL_PAD_TO=0x7f8000
++++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++++CONFIG_SPL_POWER=y
++++CONFIG_SPL_ATF=y
++++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++++CONFIG_CMD_BOOTZ=y
++++CONFIG_CMD_GPIO=y
++++CONFIG_CMD_GPT=y
++++CONFIG_CMD_MMC=y
++++CONFIG_CMD_USB=y
++++CONFIG_CMD_ROCKUSB=y
++++CONFIG_CMD_USB_MASS_STORAGE=y
++++# CONFIG_CMD_SETEXPR is not set
++++CONFIG_CMD_TIME=y
++++CONFIG_CMD_REGULATOR=y
++++CONFIG_SPL_OF_CONTROL=y
++++CONFIG_TPL_OF_CONTROL=y
++++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++++CONFIG_TPL_OF_PLATDATA=y
++++CONFIG_ENV_IS_IN_MMC=y
++++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++++CONFIG_SYS_MMC_ENV_DEV=0
++++CONFIG_TPL_DM=y
++++CONFIG_SPL_DM_SEQ_ALIAS=y
++++CONFIG_REGMAP=y
++++CONFIG_SPL_REGMAP=y
++++CONFIG_TPL_REGMAP=y
++++CONFIG_SYSCON=y
++++CONFIG_SPL_SYSCON=y
++++CONFIG_TPL_SYSCON=y
++++CONFIG_CLK=y
++++CONFIG_SPL_CLK=y
++++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++++CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
++++CONFIG_ROCKCHIP_GPIO=y
++++CONFIG_SYS_I2C_ROCKCHIP=y
++++CONFIG_MMC_DW=y
++++CONFIG_MMC_DW_ROCKCHIP=y
++++CONFIG_PHY_MOTORCOMM=y
++++CONFIG_PHY_REALTEK=y
++++CONFIG_DM_MDIO=y
++++CONFIG_DM_ETH_PHY=y
++++CONFIG_PHY_GIGE=y
++++CONFIG_ETH_DESIGNWARE=y
++++CONFIG_GMAC_ROCKCHIP=y
++++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++++CONFIG_PINCTRL=y
++++CONFIG_SPL_PINCTRL=y
++++CONFIG_DM_PMIC=y
++++CONFIG_PMIC_RK8XX=y
++++CONFIG_SPL_DM_REGULATOR=y
++++CONFIG_DM_REGULATOR_FIXED=y
++++CONFIG_SPL_DM_REGULATOR_FIXED=y
++++CONFIG_DM_REGULATOR_GPIO=y
++++CONFIG_SPL_DM_REGULATOR_GPIO=y
++++CONFIG_REGULATOR_RK8XX=y
++++CONFIG_PWM_ROCKCHIP=y
++++CONFIG_RAM=y
++++CONFIG_SPL_RAM=y
++++CONFIG_TPL_RAM=y
++++CONFIG_DM_RNG=y
++++CONFIG_RNG_ROCKCHIP=y
++++CONFIG_BAUDRATE=1500000
++++CONFIG_DEBUG_UART_SHIFT=2
++++CONFIG_SYS_NS16550_MEM32=y
++++CONFIG_SYSINFO=y
++++CONFIG_SYSRESET=y
++++# CONFIG_TPL_SYSRESET is not set
++++CONFIG_USB=y
++++CONFIG_DM_USB_GADGET=y
++++CONFIG_USB_XHCI_HCD=y
++++CONFIG_USB_EHCI_HCD=y
++++CONFIG_USB_EHCI_GENERIC=y
++++CONFIG_USB_OHCI_HCD=y
++++CONFIG_USB_OHCI_GENERIC=y
++++CONFIG_USB_DWC3=y
++++CONFIG_USB_DWC3_GENERIC=y
++++CONFIG_USB_GADGET=y
++++CONFIG_USB_GADGET_DWC2_OTG=y
++++CONFIG_USB_FUNCTION_ROCKUSB=y
++++CONFIG_SPL_TINY_MEMSET=y
++++CONFIG_TPL_TINY_MEMSET=y
++++CONFIG_ERRNO_STR=y
++-- 
++2.43.0
++
+diff --git a/patches/openwrt/0015-rockchip-Add-support-for-FriendlyARM-NanoPi-R2S-Plus.patch b/patches/openwrt/0015-rockchip-Add-support-for-FriendlyARM-NanoPi-R2S-Plus.patch
+new file mode 100644
+index 00000000..4eeea39d
+--- /dev/null
++++ b/patches/openwrt/0015-rockchip-Add-support-for-FriendlyARM-NanoPi-R2S-Plus.patch
+@@ -0,0 +1,93 @@
++From 7817847f476c9538d41209a4e1772d1a10896a2f Mon Sep 17 00:00:00 2001
++From: Grische <github@grische.xyz>
++Date: Wed, 17 Jun 2026 14:09:18 +0200
++Subject: [PATCH 2/2] rockchip: Add support for FriendlyARM NanoPi R2S Plus
++
++The NanoPi R2S Plus is a NanoPi R2S with on-board eMMC added. The device
++tree (rk3328-nanopi-r2s-plus.dts) is already present in kernel 6.6.142,
++so only the image and board.d definitions are needed; the matching
++U-Boot is added separately.
++
++Hardware
++--------
++Rockchip RK3328 ARM64 (4 cores)
++1GB DDR4 RAM
++on-board eMMC
++1x 1000 Base-T (native, RTL8211 via GMAC) - WAN
++1x 1000 Base-T (USB 3.0, RTL8153) - LAN
++1x USB 2.0 Type-A
++microSD Slot
++1 Button (Reset)
++LEDs (SYS, WAN, LAN)
++USB Type-C power (5V)
++
++The MAC addresses are derived from the eMMC CID, so they are stable
++regardless of whether the device boots from microSD or eMMC.
++
++Installation
++------------
++Uncompress the OpenWrt sysupgrade and write it to the microSD card or
++internal eMMC using dd.
++
++Signed-off-by: Grische <github@grische.xyz>
++Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
++---
++ .../linux/rockchip/armv8/base-files/etc/board.d/01_leds   | 1 +
++ .../rockchip/armv8/base-files/etc/board.d/02_network      | 2 ++
++ target/linux/rockchip/image/armv8.mk                      | 8 ++++++++
++ 3 files changed, 11 insertions(+)
++
++diff --git a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
++index 6e2c95ada7..e4e41a95a9 100644
++--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
++@@ -11,6 +11,7 @@ case $board in
++ friendlyarm,nanopi-r2c|\
++ friendlyarm,nanopi-r2c-plus|\
++ friendlyarm,nanopi-r2s|\
+++friendlyarm,nanopi-r2s-plus|\
++ friendlyarm,nanopi-r3s|\
++ friendlyarm,nanopi-r4s|\
++ friendlyarm,nanopi-r4s-enterprise|\
++diff --git a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
++index 606e77410b..bd4c135b8e 100644
++--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
++@@ -11,6 +11,7 @@ rockchip_setup_interfaces()
++ 	friendlyarm,nanopi-r2c|\
++ 	friendlyarm,nanopi-r2c-plus|\
++ 	friendlyarm,nanopi-r2s|\
+++	friendlyarm,nanopi-r2s-plus|\
++ 	friendlyarm,nanopi-r3s|\
++ 	friendlyarm,nanopi-r4s|\
++ 	friendlyarm,nanopi-r4s-enterprise|\
++@@ -65,6 +66,7 @@ rockchip_setup_macs()
++ 		lan_mac=$(macaddr_add "$wan_mac" 1)
++ 		;;
++ 	friendlyarm,nanopi-r2c-plus|\
+++	friendlyarm,nanopi-r2s-plus|\
++ 	friendlyarm,nanopi-r4s|\
++ 	friendlyarm,nanopi-r5s|\
++ 	sinovoip,rk3568-bpi-r2pro)
++diff --git a/target/linux/rockchip/image/armv8.mk b/target/linux/rockchip/image/armv8.mk
++index c28835d5cd..2fa503012d 100644
++--- a/target/linux/rockchip/image/armv8.mk
+++++ b/target/linux/rockchip/image/armv8.mk
++@@ -65,6 +65,14 @@ define Device/friendlyarm_nanopi-r2s
++ endef
++ TARGET_DEVICES += friendlyarm_nanopi-r2s
++ 
+++define Device/friendlyarm_nanopi-r2s-plus
+++  DEVICE_VENDOR := FriendlyARM
+++  DEVICE_MODEL := NanoPi R2S Plus
+++  SOC := rk3328
+++  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+++endef
+++TARGET_DEVICES += friendlyarm_nanopi-r2s-plus
+++
++ define Device/friendlyarm_nanopi-r3s
++   DEVICE_VENDOR := FriendlyARM
++   DEVICE_MODEL := NanoPi R3S
++-- 
++2.43.0
++
+-- 
+2.43.0
+

--- a/patches/0002-rockchip-armv8-add-support-for-FriendlyElec-NanoPi-R.patch
+++ b/patches/0002-rockchip-armv8-add-support-for-FriendlyElec-NanoPi-R.patch
@@ -1,0 +1,41 @@
+From a3673aaedd9e801686193c7f47c13d9cb0b11ada Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Wed, 17 Jun 2026 14:27:25 +0200
+Subject: [PATCH 2/2] rockchip-armv8: add support for FriendlyElec NanoPi R2S
+ Plus
+
+Register the NanoPi R2S Plus, a NanoPi R2S with on-board eMMC sharing
+the same RK3328 SoC. Sysupgrade only, no factory image.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ docs/user/supported_devices.rst | 1 +
+ targets/rockchip-armv8          | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/docs/user/supported_devices.rst b/docs/user/supported_devices.rst
+index ea29e9bc..40c90bff 100644
+--- a/docs/user/supported_devices.rst
++++ b/docs/user/supported_devices.rst
+@@ -632,6 +632,7 @@ rockchip-armv8
+ * FriendlyElec
+ 
+   - NanoPi R2S
++  - NanoPi R2S Plus
+   - NanoPi R3S
+   - NanoPi R4S (4GB LPDDR4)
+ 
+diff --git a/targets/rockchip-armv8 b/targets/rockchip-armv8
+index 9cc8a220..4e1a256d 100644
+--- a/targets/rockchip-armv8
++++ b/targets/rockchip-armv8
+@@ -4,5 +4,6 @@ defaults {
+ }
+ 
+ device('friendlyelec-nanopi-r2s', 'friendlyarm_nanopi-r2s')
++device('friendlyelec-nanopi-r2s-plus', 'friendlyarm_nanopi-r2s-plus')
+ device('friendlyelec-nanopi-r3s', 'friendlyarm_nanopi-r3s')
+ device('friendlyelec-nanopi-r4s', 'friendlyarm_nanopi-r4s') -- 4GB LPDDR4
+-- 
+2.43.0
+


### PR DESCRIPTION
For our beloved @istrator2 😉 

How to flash to eMMC:
1. Write the uncompressed sysupgrade image to sdcard 
2. Hold the "Mask" button while powering on the device
3. Let it boot into gluon
4. Copy the compressed(!) sysupgrade image to the machine's /tmp folder (doesn't matter if setup mode or not) 
5. Run: `gunzip -c /tmp/gluon-...-friendlyarm_nanopi-r2s-plus-squashfs-sysupgrade.img.gz | dd of=/dev/mmcblk1 bs=4M conv=fsync`
6. Power the device off, remove the sdcard and power it back on (don't touch the "Mask" button)