### PR TITLE
patches: fix VXLAN for dwmac1000 on ipq806x

### DIFF
--- a/patches/0001-ipq806x-stop-dwmac1000-dropping-zero-UDP6-checksum-f.patch
+++ b/patches/0001-ipq806x-stop-dwmac1000-dropping-zero-UDP6-checksum-f.patch
@@ -1,0 +1,181 @@
+From 0914598416a6862c974c3fdf20482e00f237ef5d Mon Sep 17 00:00:00 2001
+From: Grische <github@grische.xyz>
+Date: Wed, 1 Jul 2026 17:06:57 +0000
+Subject: [PATCH] ipq806x: stop dwmac1000 dropping zero-UDP6-checksum frames
+
+The dwmac1000 (GMAC) Rx path drops frames carrying a zero UDP-over-IPv6
+checksum, which is legal for tunnels (RFC 6935/6936, e.g. VXLAN with
+udp6zerocsumtx). The checksum offload engine flags them as a payload
+checksum error and the MAC discards them in the Rx FIFO, so a
+batman-adv/VXLAN wired mesh over ipq806x (Aruba AP-32x, Extreme AP3935)
+never forms a neighbour; native IP traffic is unaffected.
+
+Stop the descriptor parser from discarding a checksum-only error and set
+DMA_CONTROL_DT so the MAC delivers such frames. stmmac_rx() then marks
+them CHECKSUM_NONE for the stack to verify, mirroring the dwmac4 fixes
+644b8437ccef and fe4042797651.
+
+Link: https://lore.kernel.org/all/20250625132117.1b3264e8@kernel.org/
+---
+ ...ix-Rx-of-zero-UDP6-checksum-frames-o.patch | 149 ++++++++++++++++++
+ 1 file changed, 149 insertions(+)
+ create mode 100644 patches/openwrt/0014-generic-stmmac-fix-Rx-of-zero-UDP6-checksum-frames-o.patch
+
+diff --git a/patches/openwrt/0014-generic-stmmac-fix-Rx-of-zero-UDP6-checksum-frames-o.patch b/patches/openwrt/0014-generic-stmmac-fix-Rx-of-zero-UDP6-checksum-frames-o.patch
+new file mode 100644
+index 00000000..0c7a5d30
+--- /dev/null
++++ b/patches/openwrt/0014-generic-stmmac-fix-Rx-of-zero-UDP6-checksum-frames-o.patch
+@@ -0,0 +1,149 @@
++From ac289b128b85c4f3a52d035f1c57a9e144e472c8 Mon Sep 17 00:00:00 2001
++From: Grische <github@grische.xyz>
++Date: Wed, 1 Jul 2026 17:05:11 +0000
++Subject: [PATCH] generic: stmmac: fix Rx of zero-UDP6-checksum frames on
++ dwmac1000
++
++The dwmac1000 (GMAC) Rx path drops frames carrying a zero UDP-over-IPv6
++checksum, which is legal for tunnels (RFC 6935/6936, e.g. VXLAN with
++udp6zerocsumtx): the checksum offload engine flags them as a payload
++checksum error and the MAC drops them in the Rx FIFO. A batman-adv/VXLAN
++wired mesh over ipq806x (Aruba AP-32x, Extreme AP3935) therefore never
++forms a neighbour, while native IP traffic is unaffected.
++
++Add the dwmac1000 counterpart of the upstream dwmac4 fix (644b8437ccef
++and fe4042797651): stop the descriptor parser discarding a checksum-only
++error, and set DMA_CONTROL_DT so the MAC delivers such frames; stmmac_rx()
++then marks them CHECKSUM_NONE for the stack to verify. The generic
++CHECKSUM_NONE handling (ee0aace5f844) is already present in 6.6.143. Not
++yet upstream for dwmac1000, so kept in pending-6.6.
++
++Assisted-by: Claude:claude-opus-4-8
++---
++ ...1000-don-t-discard-frames-with-only-.patch | 52 ++++++++++++++++++
++ ...1000-stop-hardware-from-dropping-che.patch | 54 +++++++++++++++++++
++ 2 files changed, 106 insertions(+)
++ create mode 100644 target/linux/generic/pending-6.6/742-01-net-stmmac-dwmac1000-don-t-discard-frames-with-only-.patch
++ create mode 100644 target/linux/generic/pending-6.6/742-02-net-stmmac-dwmac1000-stop-hardware-from-dropping-che.patch
++
++diff --git a/target/linux/generic/pending-6.6/742-01-net-stmmac-dwmac1000-don-t-discard-frames-with-only-.patch b/target/linux/generic/pending-6.6/742-01-net-stmmac-dwmac1000-don-t-discard-frames-with-only-.patch
++new file mode 100644
++index 0000000000..ccf526260c
++--- /dev/null
+++++ b/target/linux/generic/pending-6.6/742-01-net-stmmac-dwmac1000-don-t-discard-frames-with-only-.patch
++@@ -0,0 +1,52 @@
+++From c62ec335ed8252a079539f9fdff50aebe6f84d57 Mon Sep 17 00:00:00 2001
+++From: Grische <github@grische.xyz>
+++Date: Wed, 1 Jul 2026 17:24:49 +0000
+++Subject: [PATCH 1/2] net: stmmac: dwmac1000: don't discard frames with only a
+++ checksum error
+++
+++Do not drop an otherwise-good frame when the hardware only reports a
+++checksum error.
+++
+++enh_desc_get_rx_status() returns discard_frame whenever the Rx
+++descriptor Error Summary (ES) bit is set. On the GMAC the ES bit is also
+++raised for an L3/L4 checksum mismatch on its own, as the existing comment
+++above the enh_desc_coe_rdes0() call already notes. Such frames are
+++therefore discarded in the driver before their checksum status is
+++evaluated, instead of being delivered with CHECKSUM_NONE for the stack to
+++verify.
+++
+++Only return discard_frame when a genuine L2 error bit is set. A
+++checksum-only error then falls through to enh_desc_coe_rdes0(), which
+++already reports csum_none, so stmmac_rx() marks the skb CHECKSUM_NONE.
+++This aligns enh_desc with dwmac4, whose Error Summary check does not
+++cover the checksum bits.
+++
+++This is a preparatory step for disabling the hardware filter that drops
+++frames which do not pass checksum validation.
+++
+++Assisted-by: Claude:claude-opus-4-8
+++Signed-off-by: Grische <github@grische.xyz>
+++---
+++ drivers/net/ethernet/stmicro/stmmac/enh_desc.c | 6 +++++-
+++ 1 file changed, 5 insertions(+), 1 deletion(-)
+++
+++diff --git a/drivers/net/ethernet/stmicro/stmmac/enh_desc.c b/drivers/net/ethernet/stmicro/stmmac/enh_desc.c
+++index 937b7a0466fc..6b7a59e2d6de 100644
+++--- a/drivers/net/ethernet/stmicro/stmmac/enh_desc.c
++++++ b/drivers/net/ethernet/stmicro/stmmac/enh_desc.c
+++@@ -214,7 +214,11 @@ static int enh_desc_get_rx_status(struct stmmac_extra_stats *x,
+++ 		if (unlikely(rdes0 & RDES0_CRC_ERROR)) {
+++ 			x->rx_crc_errors++;
+++ 		}
+++-		ret = discard_frame;
++++		if (rdes0 & (RDES0_DESCRIPTOR_ERROR | RDES0_OVERFLOW_ERROR |
++++			     RDES0_COLLISION | RDES0_RECEIVE_WATCHDOG |
++++			     RDES0_MII_ERROR | RDES0_CRC_ERROR |
++++			     RDES0_LENGTH_ERROR))
++++			ret = discard_frame;
+++ 	}
+++ 
+++ 	/* After a payload csum error, the ES bit is set.
+++-- 
+++2.54.0
+++
++diff --git a/target/linux/generic/pending-6.6/742-02-net-stmmac-dwmac1000-stop-hardware-from-dropping-che.patch b/target/linux/generic/pending-6.6/742-02-net-stmmac-dwmac1000-stop-hardware-from-dropping-che.patch
++new file mode 100644
++index 0000000000..97717677ae
++--- /dev/null
+++++ b/target/linux/generic/pending-6.6/742-02-net-stmmac-dwmac1000-stop-hardware-from-dropping-che.patch
++@@ -0,0 +1,54 @@
+++From e353107f43cd4b5d55151d12cd83145ca617679a Mon Sep 17 00:00:00 2001
+++From: Grische <github@grische.xyz>
+++Date: Wed, 1 Jul 2026 17:24:54 +0000
+++Subject: [PATCH 2/2] net: stmmac: dwmac1000: stop hardware from dropping
+++ checksum-error packets
+++
+++Tell the MAC not to discard frames that fail TCP/IP checksum validation.
+++
+++By default, when the checksum offload engine (CoE) is enabled, the
+++dwmac1000 MAC silently drops any frame for which the engine detects a
+++checksum error, before it is passed to the driver. These frames are not
+++reported and are not counted as dropped.
+++
+++Set the DMA_CONTROL_DT bit when initializing the Rx operation mode so
+++that such frames are delivered instead of dropped. CoE remains enabled;
+++the descriptor error status is propagated and stmmac_rx() marks the skb
+++CHECKSUM_NONE, letting the stack verify and drop the packet while
+++updating statistics. This is the dwmac1000 equivalent of
+++commit fe4042797651 ("net: stmmac: dwmac4: stop hardware from dropping
+++checksum-error packets").
+++
+++Without this, a frame carrying a zero UDP-over-IPv6 checksum (legal for
+++tunnels per RFC 6935/6936, e.g. VXLAN with udp6zerocsumtx) is treated as
+++a payload checksum error and dropped in the Rx FIFO. This was observed on
+++a Qualcomm ipq806x GMAC: a peer's 171 such frames produced zero
+++rx_packets/rx_errors on the receiver.
+++
+++Link: https://lore.kernel.org/all/20250625132117.1b3264e8@kernel.org/
+++
+++It depends on the previous patch that avoids discarding checksum-error
+++frames in the descriptor parser.
+++
+++Assisted-by: Claude:claude-opus-4-8
+++Signed-off-by: Grische <github@grische.xyz>
+++---
+++ drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c | 2 ++
+++ 1 file changed, 2 insertions(+)
+++
+++diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
+++index daf79cdbd3ec..abcf5abefa0c 100644
+++--- a/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
++++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac1000_dma.c
+++@@ -155,6 +155,8 @@ static void dwmac1000_dma_operation_mode_rx(struct stmmac_priv *priv,
+++ {
+++ 	u32 csr6 = readl(ioaddr + DMA_CONTROL);
+++ 
++++	csr6 |= DMA_CONTROL_DT;
++++
+++ 	if (mode == SF_DMA_MODE) {
+++ 		pr_debug("GMAC: enable RX store and forward mode\n");
+++ 		csr6 |= DMA_CONTROL_RSF;
+++-- 
+++2.54.0
+++
++-- 
++2.54.0
++
+-- 
+2.54.0
+


### PR DESCRIPTION
This fixes VXLAN for at least Aruba AP32x and Extreme Networks AP3935.