### PR TITLE
bump Gluon to latest v2025.1.x for kernel 6.6.142 and AP3935 fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := v2025.1.1
+GLUON_GIT_REF := ee973143ff0a71a76db1bf219e69f185a5d9da2b # 2026-06-18
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
Updates kernel to 6.6.142 and fixes Extreme Networks AP3935 powering down WAN if there is no cable plugged in during boot among others.