### PR TITLE
bump Gluon to latest v2025.1.x for Batman v2026.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GLUON_BUILD_DIR := gluon-build
 GLUON_GIT_URL := https://github.com/freifunk-gluon/gluon.git
-GLUON_GIT_REF := ee973143ff0a71a76db1bf219e69f185a5d9da2b # 2026-06-18
+GLUON_GIT_REF := a25d6a70dbdc6ad0801168ffc0852515f1cbcea6 # 2026-07-02
 
 PATCH_DIR := ./patches
 SECRET_KEY_FILE ?= ${HOME}/.gluon-secret-key


### PR DESCRIPTION
batman v2026.2

Compare:
https://github.com/freifunk-gluon/gluon/compare/ee973143ff0a71a76db1bf219e69f185a5d9da2b...a25d6a70dbdc6ad0801168ffc0852515f1cbcea6