### PR TITLE
site: fix map URL

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -152,9 +152,9 @@
   },
 
   custom_banner = {
-    enabled     = true,                         -- optional (enabled by default)
-    map_url     = 'https://map.ffmuc.net/#!/',  -- optional (skipped by default)
-    contact_url = 'https://ffmuc.net/kontakt/', -- optional (skipped by default)
+    enabled     = true,                            -- optional (enabled by default)
+    map_url     = 'https://map.ffmuc.net/#/map/',  -- optional (skipped by default)
+    contact_url = 'https://ffmuc.net/kontakt/',    -- optional (skipped by default)
   },
 
   node_whisperer = {


### PR DESCRIPTION
Der Map Link ist nicht mehr korrekt:

` Node Info: https://map.ffmuc.net/#!/d41ad113b408`

Der sollte das hier sein:

`Node Info: https://map.ffmuc.net/#/map/d41ad113b408`