### PR TITLE
site: use https for FQDN URL

### DIFF
--- a/image-customization.lua
+++ b/image-customization.lua
@@ -115,14 +115,10 @@ pkgs_pci = {
 
 
 -- we want TLS on all devices for the firmware downloader to use HTTPS
-include_tls = true
-
-if include_tls then
-    features({ 'tls' })
-    packages({
-        'openssh-sftp-server', -- for OpenSSH 9: https://www.openssh.com/txt/release-9.0
-    })
-end
+features({ 'tls' })
+packages({
+    'openssh-sftp-server', -- for OpenSSH 9: https://www.openssh.com/txt/release-9.0
+})
 
 include_usb = true
 

--- a/site.conf
+++ b/site.conf
@@ -56,7 +56,7 @@
       stable = {
         name = 'stable',
         mirrors = {
-          '//firmware.ffmuc.net/stable/sysupgrade',
+          'https://firmware.ffmuc.net/stable/sysupgrade',
           'http://5.1.66.255/stable/sysupgrade',
           'http://185.150.99.255/stable/sysupgrade',
           'http://[2001:678:e68:f000::]/stable/sysupgrade',
@@ -79,7 +79,7 @@
       testing = {
         name = 'testing',
         mirrors = {
-          '//firmware.ffmuc.net/testing/sysupgrade',
+          'https://firmware.ffmuc.net/testing/sysupgrade',
           'http://5.1.66.255/testing/sysupgrade',
           'http://185.150.99.255/testing/sysupgrade',
           'http://[2001:678:e68:f000::]/testing/sysupgrade',
@@ -102,7 +102,7 @@
       experimental = {
         name = 'experimental',
         mirrors = {
-          '//firmware.ffmuc.net/experimental/sysupgrade',
+          'https://firmware.ffmuc.net/experimental/sysupgrade',
           'http://5.1.66.255/experimental/sysupgrade',
           'http://185.150.99.255/experimental/sysupgrade',
           'http://[2001:678:e68:f000::]/experimental/sysupgrade',


### PR DESCRIPTION
only `v2025.1.x` after https://github.com/freifunk-gluon/packages/pull/282 is merged